### PR TITLE
Relaxed checking opt

### DIFF
--- a/oletools/olevba.py
+++ b/oletools/olevba.py
@@ -2751,21 +2751,12 @@ class VBA_Parser_CLI(VBA_Parser):
     of olevba. (see VBA_Parser)
     """
 
-    def __init__(self, filename, data=None, container=None):
+    def __init__(self, *args, **kwargs):
         """
         Constructor for VBA_Parser_CLI.
-        Calls __init__ from VBA_Parser
-
-        :param filename: filename or path of file to parse, or file-like object
-
-        :param data: None or bytes str, if None the file will be read from disk (or from the file-like object).
-        If data is provided as a bytes string, it will be parsed as the content of the file in memory,
-        and not read from disk. Note: files must be read in binary mode, i.e. open(f, 'rb').
-
-        :param container: str, path and filename of container if the file is within
-        a zip archive, None otherwise.
+        Calls __init__ from VBA_Parser with all arguments --> see doc there
         """
-        super(VBA_Parser_CLI, self).__init__(filename, data=data, container=container)
+        super(VBA_Parser_CLI, self).__init__(*args, **kwargs)
 
 
     def print_analysis(self, show_decoded_strings=False, deobfuscate=False):

--- a/oletools/olevba.py
+++ b/oletools/olevba.py
@@ -1515,7 +1515,7 @@ def _extract_vba(ole, vba_root, project_path, dir_path, relaxed=False):
             vba_codec = 'cp%d' % projectcodepage_codepage
             log.debug("ModuleName = {0}".format(modulename_modulename))
             log.debug("ModuleNameUnicode = {0}".format(uni_out(modulename_unicode_modulename_unicode)))
-            log.debug("StreamName = {0}".format(uni_out(modulestreamname_streamname)))
+            log.debug("StreamName = {0}".format(modulestreamname_streamname))
             streamname_unicode = modulestreamname_streamname.decode(vba_codec)
             log.debug("StreamName.decode('%s') = %s" % (vba_codec, uni_out(streamname_unicode)))
             log.debug("StreamNameUnicode = {0}".format(uni_out(modulestreamname_streamname_unicode)))
@@ -1526,13 +1526,15 @@ def _extract_vba(ole, vba_root, project_path, dir_path, relaxed=False):
                         modulename_unicode_modulename_unicode, \
                         modulestreamname_streamname_unicode
             for stream_name in try_names:
+                # TODO: if olefile._find were less private, could replace this
+                #        try-except with calls to it
                 try:
                     code_path = vba_root + u'VBA/' + stream_name
                     log.debug('opening VBA code stream %s' % uni_out(code_path))
                     code_data = ole.openstream(code_path).read()
                     break
                 except IOError as ioe:
-                    log.debug('failed to open stream {} ({}), try other name'
+                    log.debug('failed to open stream VBA/{} ({}), try other name'
                               .format(uni_out(stream_name), ioe))
 
             if code_data is None:
@@ -2507,7 +2509,11 @@ class VBA_Parser(object):
                 try:
                     data = ole._open(d.isectStart, d.size).read()
                     log.debug('Read %d bytes' % len(data))
-                    log.debug(repr(data))
+                    if len(data) > 200:
+                        log.debug('{}...[much more data]...{}'
+                                  .format(repr(data[:100]), repr(data[-50:])))
+                    else:
+                        log.debug(repr(data))
                     if 'Attribut' in data:
                         log.debug('Found VBA compressed code')
                         self.contains_macros = True

--- a/oletools/olevba.py
+++ b/oletools/olevba.py
@@ -1533,6 +1533,9 @@ def _extract_vba(ole, vba_root, project_path, dir_path):
                               .format(uni_out(stream_name), ioe))
 
             if code_data is None:
+                log.warning("Could not find module {}!"
+                            .format('/'.join(uni_out(stream_name)
+                                             for stream_name in try_names)))
                 continue
 
             log.debug("length of code_data = {0}".format(len(code_data)))
@@ -1554,9 +1557,9 @@ def _extract_vba(ole, vba_root, project_path, dir_path):
             else:
                 log.warning("module stream {0} has code data length 0".format(modulestreamname_streamname))
         except Exception as exc:
-            log.info('Error parsing module {} of {} in _extract_vba:'
-                      .format(projectmodule_index, projectmodules_count),
-                     exc_info=True)
+            log.warning('Error parsing module {} of {} in _extract_vba:'
+                        .format(projectmodule_index, projectmodules_count),
+                        exc_info=True)
     _ = unused   # make pylint happy: now variable "unused" is being used ;-)
     return
 

--- a/oletools/olevba.py
+++ b/oletools/olevba.py
@@ -2470,7 +2470,7 @@ class VBA_Parser(object):
 
         :return: bool, True if at least one VBA project has been found, False otherwise
         """
-        #TODO: return None or raise exception if format not supported like PPT 97-2003
+        #TODO: return None or raise exception if format not supported
         #TODO: return the number of VBA projects found instead of True/False?
         # if this method was already called, return the previous result:
         if self.contains_macros is not None:

--- a/oletools/olevba.py
+++ b/oletools/olevba.py
@@ -2517,8 +2517,9 @@ class VBA_Parser(object):
                     if 'Attribut' in data:
                         log.debug('Found VBA compressed code')
                         self.contains_macros = True
-                except:
-                    log.exception('Error when reading OLE Stream %r' % d.name)
+                except IOError as exc:
+                    log.info('Error when reading OLE Stream %r' % d.name)
+                    log.debug('Trace:', exc_trace=True)
         return self.contains_macros
 
     def extract_macros(self):

--- a/oletools/olevba.py
+++ b/oletools/olevba.py
@@ -1416,6 +1416,9 @@ def _extract_vba(ole, vba_root, project_path, dir_path):
     projectmodules_projectcookierecord_cookie = struct.unpack("<H", dir_stream.read(2))[0]
     unused = projectmodules_projectcookierecord_cookie
 
+    # short function to simplify unicode text output
+    uni_out = lambda unicode_text: unicode_text.encode('utf-8', 'replace')
+
     log.debug("parsing {0} modules".format(projectmodules_count))
     for projectmodule_index in xrange(0, projectmodules_count):
         try:
@@ -1428,9 +1431,10 @@ def _extract_vba(ole, vba_root, project_path, dir_path):
             if section_id == 0x0047:
                 modulename_unicode_id = section_id
                 modulename_unicode_sizeof_modulename_unicode = struct.unpack("<L", dir_stream.read(4))[0]
-                modulename_unicode_modulename_unicode = dir_stream.read(modulename_unicode_sizeof_modulename_unicode)
+                modulename_unicode_modulename_unicode = dir_stream.read(
+                    modulename_unicode_sizeof_modulename_unicode).decode('UTF-16LE', 'replace')
+                    # just guessing that this is the same encoding as used in OleFileIO
                 unused = modulename_unicode_id
-                unused = modulename_unicode_modulename_unicode
                 section_id = struct.unpack("<H", dir_stream.read(2))[0]
             if section_id == 0x001A:
                 modulestreamname_id = section_id
@@ -1439,7 +1443,9 @@ def _extract_vba(ole, vba_root, project_path, dir_path):
                 modulestreamname_reserved = struct.unpack("<H", dir_stream.read(2))[0]
                 check_value('MODULESTREAMNAME_Reserved', 0x0032, modulestreamname_reserved)
                 modulestreamname_sizeof_streamname_unicode = struct.unpack("<L", dir_stream.read(4))[0]
-                modulestreamname_streamname_unicode = dir_stream.read(modulestreamname_sizeof_streamname_unicode)
+                modulestreamname_streamname_unicode = dir_stream.read(
+                    modulestreamname_sizeof_streamname_unicode).decode('UTF-16LE', 'replace')
+                    # just guessing that this is the same encoding as used in OleFileIO
                 unused = modulestreamname_id
                 section_id = struct.unpack("<H", dir_stream.read(2))[0]
             if section_id == 0x001C:
@@ -1505,16 +1511,30 @@ def _extract_vba(ole, vba_root, project_path, dir_path):
             log.debug('Project CodePage = %d' % projectcodepage_codepage)
             vba_codec = 'cp%d' % projectcodepage_codepage
             log.debug("ModuleName = {0}".format(modulename_modulename))
-            log.debug("StreamName = {0}".format(repr(modulestreamname_streamname)))
+            log.debug("ModuleNameUnicode = {0}".format(uni_out(modulename_unicode_modulename_unicode)))
+            log.debug("StreamName = {0}".format(uni_out(modulestreamname_streamname)))
             streamname_unicode = modulestreamname_streamname.decode(vba_codec)
-            log.debug("StreamName.decode('%s') = %s" % (vba_codec, repr(streamname_unicode)))
-            log.debug("StreamNameUnicode = {0}".format(repr(modulestreamname_streamname_unicode)))
+            log.debug("StreamName.decode('%s') = %s" % (vba_codec, uni_out(streamname_unicode)))
+            log.debug("StreamNameUnicode = {0}".format(uni_out(modulestreamname_streamname_unicode)))
             log.debug("TextOffset = {0}".format(moduleoffset_textoffset))
 
-            code_path = vba_root + u'VBA/' + streamname_unicode
-            #TODO: test if stream exists
-            log.debug('opening VBA code stream %s' % repr(code_path))
-            code_data = ole.openstream(code_path).read()
+            code_data = None
+            try_names = streamname_unicode, \
+                        modulename_unicode_modulename_unicode, \
+                        modulestreamname_streamname_unicode
+            for stream_name in try_names:
+                try:
+                    code_path = vba_root + u'VBA/' + stream_name
+                    log.debug('opening VBA code stream %s' % uni_out(code_path))
+                    code_data = ole.openstream(code_path).read()
+                    break
+                except IOError as ioe:
+                    log.debug('failed to open stream {} ({}), try other name'
+                              .format(uni_out(stream_name), ioe))
+
+            if code_data is None:
+                continue
+
             log.debug("length of code_data = {0}".format(len(code_data)))
             log.debug("offset of code_data = {0}".format(moduleoffset_textoffset))
             code_data = code_data[moduleoffset_textoffset:]

--- a/oletools/olevba.py
+++ b/oletools/olevba.py
@@ -3071,6 +3071,8 @@ def main():
                             help="logging level debug/info/warning/error/critical (default=%default)")
     parser.add_option('--deobf', dest="deobfuscate", action="store_true", default=False,
                             help="Attempt to deobfuscate VBA expressions (slow)")
+    parser.add_option('--relaxed', dest="relaxed", action="store_true", default=False,
+                            help="Do not raise errors if opening of substream fails")
 
     (options, args) = parser.parse_args()
 

--- a/oletools/ppt_parser.py
+++ b/oletools/ppt_parser.py
@@ -1365,8 +1365,8 @@ class PptParser(object):
         while True:
             start_pos = stream.tell()
             n_reads += 1
-            log.debug('read {} starting from {}'
-                      .format(BUF_SIZE, start_pos))
+            #log.debug('read {} starting from {}'
+            #          .format(BUF_SIZE, start_pos))
             buf = stream.read(BUF_SIZE)
             idx = buf.find(pattern)
             while idx != -1:


### PR DESCRIPTION
As hinted at earlier: we added a --relaxed option to olevba.

After adding my first robustify-olevba-patch (simple try-except around openstream), we realized that there are a few more cases where subfiles or substreams/modules are not parsed in case there is an error and only info- or debug-logging would reveal that there is potentially unparsed code.

To fix this, we made the parsing much stricter (e.g. raise SubstreamOpenError if cannot open module) by default. The old behaviour (accept everything silently just like MS office does) can be obtained by adding --relaxed. A few warnings are only log.info or log.debug now if --relaxed is set (per default, they raise exceptions now)

This branch is based on the yet unmerged unicode-vba-stream-names; so the first 2 commits here are the same as in the unicode-... branch.