### PR TITLE
Olevba compliant python3.5

### DIFF
--- a/oletools/mraptor.py
+++ b/oletools/mraptor.py
@@ -233,16 +233,16 @@ def main():
 
     # Print help if no arguments are passed
     if len(args) == 0:
-        print __doc__
+        print(__doc__)
         parser.print_help()
-        print '\nAn exit code is returned based on the analysis result:'
+        print('\nAn exit code is returned based on the analysis result:')
         for result in (Result_NoMacro, Result_NotMSOffice, Result_MacroOK, Result_Error, Result_Suspicious):
-            print ' - %d: %s' % (result.exit_code, result.name)
+            print(' - %d: %s' % (result.exit_code, result.name))
         sys.exit()
 
     # print banner with version
-    print 'MacroRaptor %s - http://decalage.info/python/oletools' % __version__
-    print 'This is work in progress, please report issues at %s' % URL_ISSUES
+    print('MacroRaptor %s - http://decalage.info/python/oletools' % __version__)
+    print('This is work in progress, please report issues at %s' % URL_ISSUES)
 
     logging.basicConfig(level=LOG_LEVELS[options.loglevel], format='%(levelname)-8s %(message)s')
     # enable logging in the modules:
@@ -319,9 +319,9 @@ def main():
             global_result = result
             exitcode = result.exit_code
 
-    print ''
-    print 'Flags: A=AutoExec, W=Write, X=Execute'
-    print 'Exit code: %d - %s' % (exitcode, global_result.name)
+    print('')
+    print('Flags: A=AutoExec, W=Write, X=Execute')
+    print('Exit code: %d - %s' % (exitcode, global_result.name))
     sys.exit(exitcode)
 
 if __name__ == '__main__':

--- a/oletools/mraptor.py
+++ b/oletools/mraptor.py
@@ -292,7 +292,7 @@ def main():
                 vba_code_all_modules = ''
                 try:
                     for (subfilename, stream_path, vba_filename, vba_code) in vba_parser.extract_all_macros():
-                        vba_code_all_modules += vba_code + '\n'
+                        vba_code_all_modules += vba_code.decode('utf-8','replace') + '\n'
                 except Exception as e:
                     # log.error('Error when parsing VBA macros from file %r' % full_name)
                     result = Result_Error

--- a/oletools/oledir.py
+++ b/oletools/oledir.py
@@ -94,7 +94,7 @@ STATUS_COLORS = {
 
 if __name__ == '__main__':
     # print banner with version
-    print 'oledir %s - http://decalage.info/python/oletools' % __version__
+    print('oledir %s - http://decalage.info/python/oletools' % __version__)
 
     if os.name == 'nt':
         colorclass.Windows.enable(auto_colors=True, reset_atexit=True)
@@ -126,7 +126,7 @@ if __name__ == '__main__':
     # TODO: oledir option to hexdump the raw direntries
     # TODO: olefile should be less picky about incorrect directory structures
 
-    for id in xrange(len(ole.direntries)):
+    for id in range(len(ole.direntries)):
         d = ole.direntries[id]
         if d is None:
             # this direntry is not part of the tree: either unused or an orphan

--- a/oletools/olemap.py
+++ b/oletools/olemap.py
@@ -90,14 +90,14 @@ FAT_COLORS = {
 
 if __name__ == '__main__':
     # print banner with version
-    print 'olemap %s - http://decalage.info/python/oletools' % __version__
+    print('olemap %s - http://decalage.info/python/oletools' % __version__)
 
     fname = sys.argv[1]
     ole = olefile.OleFileIO(fname)
 
-    print 'FAT:'
+    print('FAT:')
     t = tablestream.TableStream([8, 12, 8, 8], header_row=['Sector #', 'Type', 'Offset', 'Next #'])
-    for i in xrange(ole.nb_sect):
+    for i in range(ole.nb_sect):
         fat_value = ole.fat[i]
         fat_type = FAT_TYPES.get(fat_value, '<Data>')
         color_type = FAT_COLORS.get(fat_value, FAT_COLORS['default'])
@@ -106,15 +106,15 @@ if __name__ == '__main__':
         # print '%8X: %-12s offset=%08X next=%8X' % (i, fat_type, 0, fat_value)
         t.write_row(['%8X' % i, fat_type, '%08X' % offset, '%8X' % fat_value],
             colors=[None, color_type, None, None])
-    print ''
+    print('')
 
-    print 'MiniFAT:'
+    print('MiniFAT:')
     # load MiniFAT if it wasn't already done:
     ole.loadminifat()
-    for i in xrange(len(ole.minifat)):
+    for i in range(len(ole.minifat)):
         fat_value = ole.minifat[i]
         fat_type = FAT_TYPES.get(fat_value, 'Data')
-        print '%8X: %-12s offset=%08X next=%8X' % (i, fat_type, 0, fat_value)
+        print('%8X: %-12s offset=%08X next=%8X' % (i, fat_type, 0, fat_value))
 
     ole.close()
 

--- a/oletools/oletimes.py
+++ b/oletools/oletimes.py
@@ -94,6 +94,6 @@ for obj in ole.listdir(streams=True, storages=True):
     #print '- %s: mtime=%s ctime=%s' % (repr('/'.join(obj)), ole.getmtime(obj), ole.getctime(obj))
     t.add_row((repr('/'.join(obj)), dt2str(ole.getmtime(obj)), dt2str(ole.getctime(obj))))
 
-print t
+print(t)
 
 ole.close()

--- a/oletools/olevba.py
+++ b/oletools/olevba.py
@@ -1933,8 +1933,8 @@ class VBA_Scanner(object):
         # join long lines ending with " _":
         self.code = vba_collapse_long_lines(vba_code)
         self.code_hex = b''
-        self.code_hex_rev = ''
-        self.code_rev_hex = ''
+        self.code_hex_rev = b''
+        self.code_rev_hex = b''
         self.code_base64 = b''
         self.code_dridex = ''
         self.code_vba = ''
@@ -1972,9 +1972,9 @@ class VBA_Scanner(object):
             # if the code contains "StrReverse", also append the hex strings in reverse order:
             if self.strReverse:
                 # StrReverse after hex decoding:
-                self.code_hex_rev += '\n' + decoded[::-1]
+                self.code_hex_rev += b'\n' + decoded[::-1]
                 # StrReverse before hex decoding:
-                self.code_rev_hex += '\n' + binascii.unhexlify(encoded[::-1])
+                self.code_rev_hex += b'\n' + binascii.unhexlify(encoded[::-1])
                 #example: https://malwr.com/analysis/NmFlMGI4YTY1YzYyNDkwNTg1ZTBiZmY5OGI3YjlhYzU/
         #TODO: also append the full code reversed if StrReverse? (risk of false positives?)
         # Detect Base64-encoded strings
@@ -2006,6 +2006,8 @@ class VBA_Scanner(object):
                 (self.code_dridex, 'Dridex'),
                 (self.code_vba, 'VBA expression'),
         ):
+            if isinstance(code,bytes):
+                code=code.decode('utf-8','replace')
             self.autoexec_keywords += detect_autoexec(code, obfuscation)
             self.suspicious_keywords += detect_suspicious(code, obfuscation)
             self.iocs += detect_patterns(code, obfuscation)

--- a/oletools/olevba.py
+++ b/oletools/olevba.py
@@ -1854,19 +1854,19 @@ def json2ascii(json_obj, encoding='utf8', errors='replace'):
         pass
     elif isinstance(json_obj, str):
         # de-code and re-encode
-        dencoded = json_obj.decode(encoding, errors).encode(encoding, errors)
+        dencoded = json_obj
         if dencoded != json_obj:
             log.debug('json2ascii: replaced: {0} (len {1})'
                      .format(json_obj, len(json_obj)))
             log.debug('json2ascii:     with: {0} (len {1})'
                      .format(dencoded, len(dencoded)))
         return dencoded
-    elif isinstance(json_obj, str):
+    elif isinstance(json_obj, bytes):
         log.debug('json2ascii: encode unicode: {0}'
-                 .format(json_obj.encode(encoding, errors)))
+                 .format(json_obj.decode(encoding, errors)))
         # cannot put original into logger
         # print 'original: ' json_obj
-        return json_obj.encode(encoding, errors)
+        return json_obj.decode(encoding, errors)
     elif isinstance(json_obj, dict):
         for key in json_obj:
             json_obj[key] = json2ascii(json_obj[key])
@@ -3021,7 +3021,7 @@ class VBA_Parser_CLI(VBA_Parser):
                     curr_macro = {}
                     if hide_attributes:
                         # hide attribute lines:
-                        vba_code_filtered = filter_vba(vba_code)
+                        vba_code_filtered = filter_vba(vba_code.decode('utf-8','replace'))
                     else:
                         vba_code_filtered = vba_code
 

--- a/oletools/olevba.py
+++ b/oletools/olevba.py
@@ -2433,6 +2433,8 @@ class VBA_Parser(object):
         """
         log.info('Opening text file %s' % self.filename)
         # directly store the source code:
+        if isinstance(data,bytes):
+            data=data.decode('utf8','replace')
         self.vba_code_all_modules = data
         self.contains_macros = True
         # set type only if parsing succeeds
@@ -2943,7 +2945,9 @@ class VBA_Parser_CLI(VBA_Parser):
                 for (subfilename, stream_path, vba_filename, vba_code) in self.extract_all_macros():
                     if hide_attributes:
                         # hide attribute lines:
-                        vba_code_filtered = filter_vba(vba_code.decode('utf-8','replace'))
+                        if isinstance(vba_code,bytes):
+                            vba_code =vba_code.decode('utf-8','replace')
+                        vba_code_filtered = filter_vba(vba_code)
                     else:
                         vba_code_filtered = vba_code
                     print('-' * 79)

--- a/oletools/olevba.py
+++ b/oletools/olevba.py
@@ -404,7 +404,7 @@ TYPE2TAG = {
 
 
 # MSO files ActiveMime header magic
-MSO_ACTIVEMIME_HEADER = 'ActiveMime'
+MSO_ACTIVEMIME_HEADER = b'ActiveMime'
 
 MODULE_EXTENSION = "bas"
 CLASS_EXTENSION = "cls"
@@ -2333,6 +2333,8 @@ class VBA_Parser(object):
         """
         log.info('Opening MHTML file %s' % self.filename)
         try:
+            if isinstance(data,bytes):
+                data = data.decode('utf8', 'replace')
             # parse the MIME content
             # remove any leading whitespace or newline (workaround for issue in email package)
             stripped_data = data.lstrip('\r\n\t ')
@@ -2362,7 +2364,8 @@ class VBA_Parser(object):
                 # using the ActiveMime/MSO format (zlib-compressed), and Base64 encoded.
                 # decompress the zlib data starting at offset 0x32, which is the OLE container:
                 # check ActiveMime header:
-                if isinstance(part_data, str) and is_mso_file(part_data):
+
+                if (isinstance(part_data, str) or isinstance(part_data, bytes)) and is_mso_file(part_data):
                     log.debug('Found ActiveMime header, decompressing MSO container')
                     try:
                         ole_data = mso_file_extract(part_data)

--- a/oletools/olevba.py
+++ b/oletools/olevba.py
@@ -2902,7 +2902,7 @@ class VBA_Parser_CLI(VBA_Parser):
         """
         # print a waiting message only if the output is not redirected to a file:
         if sys.stdout.isatty():
-            print('Analysis...%s\r')
+            print('Analysis...\r')
             sys.stdout.flush()
         return [dict(type=kw_type, keyword=keyword, description=description)
                 for kw_type, keyword, description in self.analyze_macros(show_decoded_strings, deobfuscate)]

--- a/oletools/olevba.py
+++ b/oletools/olevba.py
@@ -239,9 +239,9 @@ except ImportError:
             # Python <2.5: standalone ElementTree install
             import elementtree.cElementTree as ET
         except ImportError:
-            raise ImportError, "lxml or ElementTree are not installed, " \
+            raise(ImportError, "lxml or ElementTree are not installed, " \
                                + "see http://codespeak.net/lxml " \
-                               + "or http://effbot.org/zone/element-index.htm"
+                               + "or http://effbot.org/zone/element-index.htm")
 
 import thirdparty.olefile as olefile
 from thirdparty.prettytable import prettytable
@@ -1105,7 +1105,7 @@ def decompress_stream(compressed_container):
                 # copy tokens (reference to a previous literal token)
                 flag_byte = ord(compressed_container[compressed_current])
                 compressed_current += 1
-                for bit_index in xrange(0, 8):
+                for bit_index in range(0, 8):
                     # log.debug('bit_index=%d / compressed_current=%d / compressed_end=%d' % (bit_index, compressed_current, compressed_end))
                     if compressed_current >= compressed_end:
                         break
@@ -1861,7 +1861,7 @@ def json2ascii(json_obj, encoding='utf8', errors='replace'):
             log.debug('json2ascii:     with: {0} (len {1})'
                      .format(dencoded, len(dencoded)))
         return dencoded
-    elif isinstance(json_obj, unicode):
+    elif isinstance(json_obj, str):
         log.debug('json2ascii: encode unicode: {0}'
                  .format(json_obj.encode(encoding, errors)))
         # cannot put original into logger
@@ -1904,18 +1904,18 @@ def print_json(json_dict=None, _json_is_last=False, **json_parts):
         json_dict = json_parts
 
     if not _have_printed_json_start:
-        print '['
+        print('[')
         _have_printed_json_start = True
 
     lines = json.dumps(json2ascii(json_dict), check_circular=False,
                            indent=4, ensure_ascii=False).splitlines()
     for line in lines[:-1]:
-        print '    {0}'.format(line)
+        print('    {0}'.format(line))
     if _json_is_last:
-        print '    {0}'.format(lines[-1])   # print last line without comma
-        print ']'
+        print('    {0}'.format(lines[-1]))   # print last line without comma
+        print(']')
     else:
-        print '    {0},'.format(lines[-1])   # print last line with comma
+        print('    {0},'.format(lines[-1]))   # print last line with comma
 
 
 class VBA_Scanner(object):
@@ -2569,7 +2569,7 @@ class VBA_Parser(object):
         # Also look for VBA code in any stream including orphans
         # (happens in some malformed files)
         ole = self.ole_file
-        for sid in xrange(len(ole.direntries)):
+        for sid in range(len(ole.direntries)):
             # check if id is already done above:
             log.debug('Checking DirEntry #%d' % sid)
             d = ole.direntries[sid]
@@ -2635,7 +2635,7 @@ class VBA_Parser(object):
             # Also look for VBA code in any stream including orphans
             # (happens in some malformed files)
             ole = self.ole_file
-            for sid in xrange(len(ole.direntries)):
+            for sid in range(len(ole.direntries)):
                 # check if id is already done above:
                 log.debug('Checking DirEntry #%d' % sid)
                 if sid in vba_stream_ids:
@@ -2870,7 +2870,7 @@ class VBA_Parser_CLI(VBA_Parser):
         """
         # print a waiting message only if the output is not redirected to a file:
         if sys.stdout.isatty():
-            print 'Analysis...\r',
+            print('Analysis...\r')
             sys.stdout.flush()
         results = self.analyze_macros(show_decoded_strings, deobfuscate)
         if results:
@@ -2886,9 +2886,9 @@ class VBA_Parser_CLI(VBA_Parser):
                 if not is_printable(description):
                     description = repr(description)
                 t.add_row((kw_type, keyword, description))
-            print t
+            print(t)
         else:
-            print 'No suspicious keyword or IOC found.'
+            print('No suspicious keyword or IOC found.')
 
     def print_analysis_json(self, show_decoded_strings=False, deobfuscate=False):
         """
@@ -2902,7 +2902,7 @@ class VBA_Parser_CLI(VBA_Parser):
         """
         # print a waiting message only if the output is not redirected to a file:
         if sys.stdout.isatty():
-            print 'Analysis...\r',
+            print('Analysis...%s\r')
             sys.stdout.flush()
         return [dict(type=kw_type, keyword=keyword, description=description)
                 for kw_type, keyword, description in self.analyze_macros(show_decoded_strings, deobfuscate)]
@@ -2931,11 +2931,11 @@ class VBA_Parser_CLI(VBA_Parser):
             display_filename = '%s in %s' % (self.filename, self.container)
         else:
             display_filename = self.filename
-        print '=' * 79
-        print 'FILE:', display_filename
+        print('=' * 79)
+        print('FILE:', display_filename)
         try:
             #TODO: handle olefile errors, when an OLE file is malformed
-            print 'Type:', self.type
+            print('Type: %s', self.type)
             if self.detect_vba_macros():
                 #print 'Contains VBA Macros:'
                 for (subfilename, stream_path, vba_filename, vba_code) in self.extract_all_macros():
@@ -2944,29 +2944,29 @@ class VBA_Parser_CLI(VBA_Parser):
                         vba_code_filtered = filter_vba(vba_code)
                     else:
                         vba_code_filtered = vba_code
-                    print '-' * 79
-                    print 'VBA MACRO %s ' % vba_filename
-                    print 'in file: %s - OLE stream: %s' % (subfilename, repr(stream_path))
+                    print('-' * 79)
+                    print('VBA MACRO %s ' % vba_filename)
+                    print('in file: %s - OLE stream: %s' % (subfilename, repr(stream_path)))
                     if display_code:
-                        print '- ' * 39
+                        print('- ' * 39)
                         # detect empty macros:
                         if vba_code_filtered.strip() == '':
-                            print '(empty macro)'
+                            print('(empty macro)')
                         else:
-                            print vba_code_filtered
+                            print(vba_code_filtered)
                 for (subfilename, stream_path, form_string) in self.extract_form_strings():
-                    print '-' * 79
-                    print 'VBA FORM STRING IN %r - OLE stream: %r' % (subfilename, stream_path)
-                    print '- ' * 39
-                    print form_string
+                    print('-' * 79)
+                    print('VBA FORM STRING IN %r - OLE stream: %r' % (subfilename, stream_path))
+                    print('- ' * 39)
+                    print(form_string)
                 if not vba_code_only:
                     # analyse the code from all modules at once:
                     self.print_analysis(show_decoded_strings, deobfuscate)
                 if show_deobfuscated_code:
-                    print 'MACRO SOURCE CODE WITH DEOBFUSCATED VBA STRINGS (EXPERIMENTAL):\n\n'
-                    print self.reveal()
+                    print('MACRO SOURCE CODE WITH DEOBFUSCATED VBA STRINGS (EXPERIMENTAL):\n\n')
+                    print(self.reveal())
             else:
-                print 'No VBA macros found.'
+                print('No VBA macros found.')
         except OlevbaBaseException:
             raise
         except Exception as exc:
@@ -2974,7 +2974,7 @@ class VBA_Parser_CLI(VBA_Parser):
             log.info('Error processing file %s (%s)' % (self.filename, exc))
             log.debug('Traceback:', exc_info=True)
             raise ProcessingError(self.filename, exc)
-        print ''
+        print('')
 
 
     def process_file_json(self, show_decoded_strings=False,
@@ -3060,7 +3060,7 @@ class VBA_Parser_CLI(VBA_Parser):
             if self.detect_vba_macros():
                 # print a waiting message only if the output is not redirected to a file:
                 if sys.stdout.isatty():
-                    print 'Analysis...\r',
+                    print('Analysis...\r')
                     sys.stdout.flush()
                 self.analyze_macros(show_decoded_strings=show_decoded_strings,
                                     deobfuscate=deobfuscate)
@@ -3078,7 +3078,7 @@ class VBA_Parser_CLI(VBA_Parser):
                                          base64obf, dridex, vba_obf)
 
             line = '%-12s %s' % (flags, self.filename)
-            print line
+            print(line)
 
             # old table display:
             # macros = autoexec = suspicious = iocs = hexstrings = 'no'
@@ -3171,7 +3171,7 @@ def main():
 
     # Print help if no arguments are passed
     if len(args) == 0:
-        print __doc__
+        print(__doc__)
         parser.print_help()
         sys.exit(RETURN_WRONG_ARGS)
 
@@ -3182,7 +3182,7 @@ def main():
                    url='http://decalage.info/python/oletools',
                    type='MetaInformation')
     else:
-        print 'olevba %s - http://decalage.info/python/oletools' % __version__
+        print('olevba %s - http://decalage.info/python/oletools' % __version__)
 
     logging.basicConfig(level=LOG_LEVELS[options.loglevel], format='%(levelname)-8s %(message)s')
     # enable logging in the modules:
@@ -3202,8 +3202,8 @@ def main():
     # Column headers (do not know how many files there will be yet, so if no output_mode
     # was specified, we will print triage for first file --> need these headers)
     if options.output_mode in ('triage', 'unspecified'):
-        print '%-12s %-65s' % ('Flags', 'Filename')
-        print '%-12s %-65s' % ('-' * 11, '-' * 65)
+        print('%-12s %-65s' % ('Flags', 'Filename'))
+        print('%-12s %-65s' % ('-' * 11, '-' * 65))
 
     previous_container = None
     count = 0
@@ -3221,14 +3221,14 @@ def main():
             if isinstance(data, Exception):
                 if isinstance(data, PathNotFoundException):
                     if options.output_mode in ('triage', 'unspecified'):
-                        print '%-12s %s - File not found' % ('?', filename)
+                        print('%-12s %s - File not found' % ('?', filename))
                     elif options.output_mode != 'json':
                         log.error('Given path %r does not exist!' % filename)
                     return_code = RETURN_FILE_NOT_FOUND if return_code == 0 \
                                                     else RETURN_SEVERAL_ERRS
                 else:
                     if options.output_mode in ('triage', 'unspecified'):
-                        print '%-12s %s - Failed to read from zip file %s' % ('?', filename, container)
+                        print('%-12s %s - Failed to read from zip file %s' % ('?', filename, container))
                     elif options.output_mode != 'json':
                         log.error('Exception opening/reading %r from zip file %r: %s'
                                       % (filename, container, data))
@@ -3255,7 +3255,7 @@ def main():
                     # print container name when it changes:
                     if container != previous_container:
                         if container is not None:
-                            print '\nFiles in %s:' % container
+                            print('\nFiles in %s:' % container)
                         previous_container = container
                     # summarized output for triage:
                     vba_parser.process_file_triage(show_decoded_strings=options.show_decoded_strings,
@@ -3273,8 +3273,8 @@ def main():
 
             except (SubstreamOpenError, UnexpectedDataError) as exc:
                 if options.output_mode in ('triage', 'unspecified'):
-                    print '%-12s %s - Error opening substream or uenxpected ' \
-                          'content' % ('?', filename)
+                    print('%-12s %s - Error opening substream or uenxpected ' \
+                          'content' % ('?', filename))
                 elif options.output_mode == 'json':
                     print_json(file=filename, type='error',
                                error=type(exc).__name__, message=str(exc))
@@ -3285,7 +3285,7 @@ def main():
                                                 else RETURN_SEVERAL_ERRS
             except FileOpenError as exc:
                 if options.output_mode in ('triage', 'unspecified'):
-                    print '%-12s %s - File format not supported' % ('?', filename)
+                    print('%-12s %s - File format not supported' % ('?', filename))
                 elif options.output_mode == 'json':
                     print_json(file=filename, type='error',
                                error=type(exc).__name__, message=str(exc))
@@ -3295,7 +3295,7 @@ def main():
                                                 else RETURN_SEVERAL_ERRS
             except ProcessingError as exc:
                 if options.output_mode in ('triage', 'unspecified'):
-                    print '%-12s %s - %s' % ('!ERROR', filename, exc.orig_exc)
+                    print('%-12s %s - %s' % ('!ERROR', filename, exc.orig_exc))
                 elif options.output_mode == 'json':
                     print_json(file=filename, type='error',
                                error=type(exc).__name__,
@@ -3310,9 +3310,9 @@ def main():
                     vba_parser.close()
 
         if options.output_mode == 'triage':
-            print '\n(Flags: OpX=OpenXML, XML=Word2003XML, MHT=MHTML, TXT=Text, M=Macros, ' \
+            print('\n(Flags: OpX=OpenXML, XML=Word2003XML, MHT=MHTML, TXT=Text, M=Macros, ' \
                   'A=Auto-executable, S=Suspicious keywords, I=IOCs, H=Hex strings, ' \
-                  'B=Base64 strings, D=Dridex strings, V=VBA strings, ?=Unknown)\n'
+                  'B=Base64 strings, D=Dridex strings, V=VBA strings, ?=Unknown)\n')
 
         if count == 1 and options.output_mode == 'unspecified':
             # if options -t, -d and -j were not specified and it's a single file, print details:

--- a/oletools/olevba.py
+++ b/oletools/olevba.py
@@ -2180,7 +2180,7 @@ class VBA_Parser(object):
             if data is None:
                 data = open(filename, 'rb').read()
             # check if it is a Word 2003 XML file (WordProcessingML): must contain the namespace
-            if 'http://schemas.microsoft.com/office/word/2003/wordml' in data:
+            if b'http://schemas.microsoft.com/office/word/2003/wordml' in data:
                 self.open_word2003xml(data)
             # store a lowercase version for the next tests:
             data_lowercase = data.lower()
@@ -2190,14 +2190,14 @@ class VBA_Parser(object):
             # and even whitespaces in between "MIME", "-", "Version" and ":". The version number is ignored.
             # And the line is case insensitive.
             # so we'll just check the presence of mime, version and multipart anywhere:
-            if self.type is None and 'mime' in data_lowercase and 'version' in data_lowercase \
-                and 'multipart' in data_lowercase:
+            if self.type is None and b'mime' in data_lowercase and b'version' in data_lowercase \
+                and b'multipart' in data_lowercase:
                 self.open_mht(data)
         #TODO: handle exceptions
         #TODO: Excel 2003 XML
             # Check if this is a plain text VBA or VBScript file:
             # To avoid scanning binary files, we simply check for some control chars:
-            if self.type is None and '\x00' not in data:
+            if self.type is None and b'\x00' not in data:
                 self.open_text(data)
         if self.type is None:
             # At this stage, could not match a known format:

--- a/oletools/olevba.py
+++ b/oletools/olevba.py
@@ -214,7 +214,7 @@ __version__ = '0.48'
 
 import sys, logging
 import struct
-import cStringIO
+from _io import StringIO
 import math
 import zipfile
 import re
@@ -1205,7 +1205,7 @@ def _extract_vba(ole, vba_root, project_path, dir_path, relaxed=False):
             else:
                 raise UnexpectedDataError(dir_path, name, expected, value)
 
-    dir_stream = cStringIO.StringIO(decompress_stream(dir_compressed))
+    dir_stream = StringIO(decompress_stream(dir_compressed))
 
     # PROJECTSYSKIND Record
     projectsyskind_id = struct.unpack("<H", dir_stream.read(2))[0]
@@ -2131,7 +2131,7 @@ class VBA_Parser(object):
             _file = filename
         else:
             # file already read in memory, make it a file-like object for zipfile:
-            _file = cStringIO.StringIO(data)
+            _file = StringIO(data)
         #self.file = _file
         self.ole_file = None
         self.ole_subfiles = []

--- a/oletools/olevba.py
+++ b/oletools/olevba.py
@@ -2131,7 +2131,7 @@ class VBA_Parser(object):
             _file = filename
         else:
             # file already read in memory, make it a file-like object for zipfile:
-            _file = StringIO(data)
+            _file = BytesIO(data)
         #self.file = _file
         self.ole_file = None
         self.ole_subfiles = []

--- a/oletools/ppt_parser.py
+++ b/oletools/ppt_parser.py
@@ -1570,4 +1570,4 @@ def iterative_decompress(stream, size, chunk_size=4096):
 
 
 if __name__ == '__main__':
-    print 'nothing here to run!'
+    print('nothing here to run!')

--- a/oletools/thirdparty/olefile/olefile.py
+++ b/oletools/thirdparty/olefile/olefile.py
@@ -1030,10 +1030,11 @@ class OleDirectoryEntry:
         #[PL] this method was added to use simple recursion instead of a complex
         # algorithm.
         # if this is not a storage or a leaf of the tree, nothing to do:
+
         if child_sid == NOSTREAM:
             return
         # check if child SID is in the proper range:
-        if child_sid<0 or child_sid>=len(self.olefile.direntries):
+        if child_sid <= 0 or child_sid >= len(self.olefile.direntries):
             self.olefile._raise_defect(DEFECT_INCORRECT, 'OLE DirEntry index out of range')
         else:
             # get child direntry:

--- a/oletools/thirdparty/olefile/olefile2.py
+++ b/oletools/thirdparty/olefile/olefile2.py
@@ -209,12 +209,7 @@ __version__ = '0.40py2'
 
 #------------------------------------------------------------------------------
 
-import string, struct, array, os.path, sys, datetime
-
-try:
-    import StringIO
-except:
-    from _io import StringIO as StringIO
+import string, StringIO, struct, array, os.path, sys, datetime
 
 #[PL] Define explicitly the public API to avoid private objects in pydoc:
 __all__ = ['OleFileIO', 'isOleFile']
@@ -227,7 +222,7 @@ elif array.array('I').itemsize == 4:
     # on 64 bits platforms, integers in an array are 32 bits:
     UINT32 = 'I'
 else:
-    raise(ValueError, 'Need to fix a bug with 32 bit arrays, please contact author...')
+    raise ValueError, 'Need to fix a bug with 32 bit arrays, please contact author...'
 
 
 #[PL] These workarounds were inspired from the Path module
@@ -248,7 +243,7 @@ except NameError:
         # is Unicode supported (Python >2.0 or >1.6 ?)
         basestring = (str, unicode)
     except NameError:
-       basestring = str
+        basestring = str
 
 #[PL] Experimental setting: if True, OLE filenames will be kept in Unicode
 # if False (default PIL behaviour), all filenames are converted to Latin-1.
@@ -258,7 +253,7 @@ KEEP_UNICODE_NAMES = False
 # command line to change it.
 DEBUG_MODE = False
 def debug_print(msg):
-    print(msg)
+    print msg
 def debug_pass(msg):
     pass
 debug = debug_pass
@@ -279,15 +274,15 @@ def set_debug_mode(debug_mode):
 MAGIC = '\320\317\021\340\241\261\032\341'
 
 #[PL]: added constants for Sector IDs (from AAF specifications)
-MAXREGSECT = 0xFFFFFFFA; # maximum SECT
-DIFSECT    = 0xFFFFFFFC; # (-4) denotes a DIFAT sector in a FAT
-FATSECT    = 0xFFFFFFFD; # (-3) denotes a FAT sector in a FAT
-ENDOFCHAIN = 0xFFFFFFFE; # (-2) end of a virtual stream chain
-FREESECT   = 0xFFFFFFFF; # (-1) unallocated sector
+MAXREGSECT = 0xFFFFFFFAL; # maximum SECT
+DIFSECT    = 0xFFFFFFFCL; # (-4) denotes a DIFAT sector in a FAT
+FATSECT    = 0xFFFFFFFDL; # (-3) denotes a FAT sector in a FAT
+ENDOFCHAIN = 0xFFFFFFFEL; # (-2) end of a virtual stream chain
+FREESECT   = 0xFFFFFFFFL; # (-1) unallocated sector
 
 #[PL]: added constants for Directory Entry IDs (from AAF specifications)
-MAXREGSID  = 0xFFFFFFFA; # maximum directory entry ID
-NOSTREAM   = 0xFFFFFFFF; # (-1) unallocated directory entry
+MAXREGSID  = 0xFFFFFFFAL; # maximum directory entry ID
+NOSTREAM   = 0xFFFFFFFFL; # (-1) unallocated directory entry
 
 #[PL] object types in storage (from AAF specifications)
 STGTY_EMPTY     = 0 # empty directory entry (according to OpenOffice.org doc)
@@ -397,6 +392,7 @@ def _clsid(clsid):
 
 try:
     # is Unicode supported ?
+    unicode
 
     def _unicode(s, errors='replace'):
         """
@@ -418,7 +414,7 @@ try:
                 return u.encode('latin_1', errors)
         except:
             # there was an error during Unicode to Latin-1 conversion:
-            raise(IOError, 'incorrect Unicode name')
+            raise IOError, 'incorrect Unicode name'
 
 except NameError:
     def _unicode(s, errors='replace'):
@@ -591,14 +587,14 @@ class OleMetadata:
         """
         Dump all metadata, for debugging purposes.
         """
-        print('Properties from SummaryInformation stream:')
+        print 'Properties from SummaryInformation stream:'
         for prop in self.SUMMARY_ATTRIBS:
             value = getattr(self, prop)
-            print('- %s: %s' % (prop, repr(value)))
-        print('Properties from DocumentSummaryInformation stream:')
+            print '- %s: %s' % (prop, repr(value))
+        print 'Properties from DocumentSummaryInformation stream:'
         for prop in self.DOCSUM_ATTRIBS:
             value = getattr(self, prop)
-            print('- %s: %s' % (prop, repr(value)))
+            print '- %s: %s' % (prop, repr(value))
 
 
 #--- _OleStream ---------------------------------------------------------------
@@ -655,7 +651,7 @@ class _OleStream(StringIO.StringIO):
         # This number should (at least) be less than the total number of
         # sectors in the given FAT:
         if nb_sectors > len(fat):
-            raise(IOError, 'malformed OLE document, stream too large')
+            raise IOError, 'malformed OLE document, stream too large'
         # optimization(?): data is first a list of strings, and join() is called
         # at the end to concatenate all in one string.
         # (this may not be really useful with recent Python versions)
@@ -663,10 +659,10 @@ class _OleStream(StringIO.StringIO):
         # if size is zero, then first sector index should be ENDOFCHAIN:
         if size == 0 and sect != ENDOFCHAIN:
             debug('size == 0 and sect != ENDOFCHAIN:')
-            raise(IOError, 'incorrect OLE sector index for empty stream')
+            raise IOError, 'incorrect OLE sector index for empty stream'
         #[PL] A fixed-length for loop is used instead of an undefined while
         # loop to avoid DoS attacks:
-        for i in range(nb_sectors):
+        for i in xrange(nb_sectors):
             # Sector index may be ENDOFCHAIN, but only if size was unknown
             if sect == ENDOFCHAIN:
                 if unknown_size:
@@ -674,7 +670,7 @@ class _OleStream(StringIO.StringIO):
                 else:
                     # else this means that the stream is smaller than declared:
                     debug('sect=ENDOFCHAIN before expected size')
-                    raise(IOError, 'incomplete OLE stream')
+                    raise IOError, 'incomplete OLE stream'
             # sector index should be within FAT:
             if sect<0 or sect>=len(fat):
                 debug('sect=%d (%X) / len(fat)=%d' % (sect, sect, len(fat)))
@@ -684,7 +680,7 @@ class _OleStream(StringIO.StringIO):
 ##                f.write(tmp_data)
 ##                f.close()
 ##                debug('data read so far: %d bytes' % len(tmp_data))
-                raise(IOError, 'incorrect OLE FAT, sector index out of range')
+                raise IOError, 'incorrect OLE FAT, sector index out of range'
             #TODO: merge this code with OleFileIO.getsect() ?
             #TODO: check if this works with 4K sectors:
             try:
@@ -692,7 +688,7 @@ class _OleStream(StringIO.StringIO):
             except:
                 debug('sect=%d, seek=%d, filesize=%d' %
                     (sect, offset+sectorsize*sect, filesize))
-                raise(IOError, 'OLE sector index out of range')
+                raise IOError, 'OLE sector index out of range'
             sector_data = fp.read(sectorsize)
             # [PL] check if there was enough data:
             # Note: if sector is the last of the file, sometimes it is not a
@@ -702,17 +698,17 @@ class _OleStream(StringIO.StringIO):
                 debug('sect=%d / len(fat)=%d, seek=%d / filesize=%d, len read=%d' %
                     (sect, len(fat), offset+sectorsize*sect, filesize, len(sector_data)))
                 debug('seek+len(read)=%d' % (offset+sectorsize*sect+len(sector_data)))
-                raise(IOError, 'incomplete OLE sector')
+                raise IOError, 'incomplete OLE sector'
             data.append(sector_data)
             # jump to next sector in the FAT:
             try:
                 sect = fat[sect]
             except IndexError:
                 # [PL] if pointer is out of the FAT an exception is raised
-                raise(IOError, 'incorrect OLE FAT, sector index out of range')
+                raise IOError, 'incorrect OLE FAT, sector index out of range'
         #[PL] Last sector should be a "end of chain" marker:
         if sect != ENDOFCHAIN:
-            raise(IOError, 'incorrect last sector index in OLE stream')
+            raise IOError, 'incorrect last sector index in OLE stream'
         data = string.join(data, "")
         # Data is truncated to the actual stream size:
         if len(data) >= size:
@@ -726,7 +722,7 @@ class _OleStream(StringIO.StringIO):
         else:
             # read data is less than expected:
             debug('len(data)=%d, size=%d' % (len(data), size))
-            raise (IOError, 'OLE stream size is less than declared')
+            raise IOError, 'OLE stream size is less than declared'
         # when all data is read in memory, StringIO constructor is called
         StringIO.StringIO.__init__(self, data)
         # Then the _OleStream object can be used as a read-only file object.
@@ -833,13 +829,13 @@ class _OleDirectoryEntry:
         # sectors, BUT apparently some implementations set it as 0xFFFFFFFFL, 1
         # or some other value so it cannot be raised as a defect in general:
         if olefile.sectorsize == 512:
-            if sizeHigh != 0 and sizeHigh != 0xFFFFFFFF:
+            if sizeHigh != 0 and sizeHigh != 0xFFFFFFFFL:
                 debug('sectorsize=%d, sizeLow=%d, sizeHigh=%d (%X)' %
                     (olefile.sectorsize, sizeLow, sizeHigh, sizeHigh))
                 olefile._raise_defect(DEFECT_UNSURE, 'incorrect OLE stream size')
             self.size = sizeLow
         else:
-            self.size = sizeLow + (int(sizeHigh)<<32)
+            self.size = sizeLow + (long(sizeHigh)<<32)
         debug(' - size: %d (sizeLow=%d, sizeHigh=%d)' % (self.size, sizeLow, sizeHigh))
 
         self.clsid = _clsid(clsid)
@@ -929,7 +925,7 @@ class _OleDirectoryEntry:
 
     def __cmp__(self, other):
         "Compare entries by name"
-        return __lt__(self.name, other.name)
+        return cmp(self.name, other.name)
         #TODO: replace by the same function as MS implementation ?
         # (order by name length first, then case-insensitive order)
 
@@ -938,13 +934,12 @@ class _OleDirectoryEntry:
         "Dump this entry, and all its subentries (for debug purposes only)"
         TYPES = ["(invalid)", "(storage)", "(stream)", "(lockbytes)",
                  "(property)", "(root)"]
-        print(" "*tab + repr(self.name), TYPES[self.entry_type]),
+        print " "*tab + repr(self.name), TYPES[self.entry_type],
         if self.entry_type in (STGTY_STREAM, STGTY_ROOT):
-            print(self.size),\
-            print("bytes"),
-        print("\n")
+            print self.size, "bytes",
+        print
         if self.entry_type in (STGTY_STORAGE, STGTY_ROOT) and self.clsid:
-            print(" "*tab + "{%s}" % self.clsid)
+            print " "*tab + "{%s}" % self.clsid
 
         for kid in self.kids:
             kid.dump(tab + 2)
@@ -1043,7 +1038,7 @@ class OleFileIO:
         """
         # added by [PL]
         if defect_level >= self._raise_defects_level:
-            raise(exception_type, message)
+            raise exception_type, message
         else:
             # just record the issue, no exception raised:
             self.parsing_issues.append((exception_type, message))
@@ -1153,7 +1148,7 @@ class OleFileIO:
         ) = struct.unpack(fmt_header, header1)
         debug( struct.unpack(fmt_header,    header1))
 
-        if self.Sig != b'\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1':
+        if self.Sig != '\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1':
             # OLE signature should always be present
             self._raise_defect(DEFECT_FATAL, "incorrect OLE signature")
         if self.clsid != '\x00'*16:
@@ -1276,10 +1271,10 @@ class OleFileIO:
             }
         nbsect = len(fat)
         nlines = (nbsect+VPL-1)/VPL
-        print("index"),
+        print "index",
         for i in range(VPL):
             print ("%8X" % i),
-        print("")
+        print ""
         for l in range(nlines):
             index = l*VPL
             print ("%8X:" % (firstindex+index)),
@@ -1294,8 +1289,8 @@ class OleFileIO:
                         nom = "    --->"
                     else:
                         nom = "%8X" % sect
-                print(nom)
-            print("")
+                print nom,
+            print ""
 
 
     def dumpsect(self, sector, firstindex=0):
@@ -1306,10 +1301,10 @@ class OleFileIO:
         tab = array.array(UINT32, sector)
         nbsect = len(tab)
         nlines = (nbsect+VPL-1)/VPL
-        print("index"),
+        print "index",
         for i in range(VPL):
             print ("%8X" % i),
-        print("")
+        print ""
         for l in range(nlines):
             index = l*VPL
             print ("%8X:" % (firstindex+index)),
@@ -1318,8 +1313,8 @@ class OleFileIO:
                     break
                 sect = tab[i]
                 nom = "%8X" % sect
-                print(nom),
-            print("")
+                print nom,
+            print ""
 
     def sect2array(self, sect):
         """
@@ -1403,9 +1398,9 @@ class OleFileIO:
             nb_difat = (self.csectFat-109 + 126)/127
             debug( "nb_difat = %d" % nb_difat )
             if self.csectDif != nb_difat:
-                raise(IOError, 'incorrect DIFAT')
+                raise IOError, 'incorrect DIFAT'
             isect_difat = self.sectDifStart
-            for i in range(nb_difat):
+            for i in xrange(nb_difat):
                 debug( "DIFAT block %d, sector %X" % (i, isect_difat) )
                 #TODO: check if corresponding FAT SID = DIFSECT
                 sector_difat = self.getsect(isect_difat)
@@ -1418,7 +1413,7 @@ class OleFileIO:
             # checks:
             if isect_difat not in [ENDOFCHAIN, FREESECT]:
                 # last DIFAT pointer value must be ENDOFCHAIN or FREESECT
-                raise(IOError, 'incorrect end of DIFAT')
+                raise IOError, 'incorrect end of DIFAT'
 ##          if len(self.fat) != self.num_fat_sectors:
 ##              # FAT should contain num_fat_sectors blocks
 ##              print "FAT length: %d instead of %d" % (len(self.fat), self.num_fat_sectors)
@@ -1658,7 +1653,7 @@ class OleFileIO:
                 if kid.name.lower() == name.lower():
                     break
             else:
-                raise(IOError, "file not found")
+                raise IOError, "file not found"
             node = kid
         return node.sid
 
@@ -1678,7 +1673,7 @@ class OleFileIO:
         sid = self._find(filename)
         entry = self.direntries[sid]
         if entry.entry_type != STGTY_STREAM:
-            raise(IOError, "this file is not a stream")
+            raise IOError, "this file is not a stream"
         return self._open(entry.isectStart, entry.size)
 
 
@@ -1760,7 +1755,7 @@ class OleFileIO:
         entry = self.direntries[sid]
         if entry.entry_type != STGTY_STREAM:
             #TODO: Should it return zero instead of raising an exception ?
-            raise(TypeError, 'object is not an OLE stream')
+            raise TypeError, 'object is not an OLE stream'
         return entry.size
 
 
@@ -1865,12 +1860,12 @@ class OleFileIO:
                     count = i32(s, offset+4)
                     value = _unicode(s[offset+8:offset+8+count*2])
                 elif type == VT_FILETIME:
-                    value = int(i32(s, offset+4)) + (int(i32(s, offset+8))<<32)
+                    value = long(i32(s, offset+4)) + (long(i32(s, offset+8))<<32)
                     # FILETIME is a 64-bit int: "number of 100ns periods
                     # since Jan 1,1601".
                     if convert_time and id not in no_conversion:
                         debug('Converting property #%d to python datetime, value=%d=%fs'
-                                %(id, value, float(value)/10000000))
+                                %(id, value, float(value)/10000000L))
                         # convert FILETIME to Python datetime.datetime
                         # inspired from http://code.activestate.com/recipes/511425-filetime-to-datetime/
                         _FILETIME_null_date = datetime.datetime(1601, 1, 1, 0, 0, 0)
@@ -1879,7 +1874,7 @@ class OleFileIO:
                     else:
                         # legacy code kept for backward compatibility: returns a
                         # number of seconds since Jan 1,1601
-                        value = value / 10000000 # seconds
+                        value = value / 10000000L # seconds
                 elif type == VT_UI1: # 1-byte unsigned integer
                     value = ord(s[offset+4])
                 elif type == VT_CLSID:
@@ -1944,8 +1939,8 @@ if __name__ == "__main__":
 
     # [PL] display quick usage info if launched from command-line
     if len(sys.argv) <= 1:
-        print(__doc__)
-        print("""
+        print __doc__
+        print """
 Launched from command line, this script parses OLE files and prints info.
 
 Usage: olefile2.py [-d] [-c] <file> [file2 ...]
@@ -1953,7 +1948,7 @@ Usage: olefile2.py [-d] [-c] <file> [file2 ...]
 Options:
 -d : debug mode (display a lot of debug information, for developers only)
 -c : check all streams (for debugging purposes)
-""")
+"""
         sys.exit()
 
     check_streams = False
@@ -1970,13 +1965,13 @@ Options:
                 continue
 
             ole = OleFileIO(filename)#, raise_defects=DEFECT_INCORRECT)
-            print("-" * 68)
-            print(filename)
-            print("-" * 68)
+            print "-" * 68
+            print filename
+            print "-" * 68
             ole.dumpdirectory()
             for streamname in ole.listdir():
                 if streamname[-1][0] == "\005":
-                    print( "%s : properties" % streamname)
+                    print streamname, ": properties"
                     props = ole.getproperties(streamname, convert_time=True)
                     props = props.items()
                     props.sort()
@@ -1991,22 +1986,22 @@ Options:
                                 if chr(c) in v:
                                     v = '(binary data)'
                                     break
-                        print("   ", k, v)
+                        print "   ", k, v
 
             if check_streams:
                 # Read all streams to check if there are errors:
-                print('\nChecking streams...')
+                print '\nChecking streams...'
                 for streamname in ole.listdir():
                     # print name using repr() to convert binary chars to \xNN:
-                    print('- %s -' %  repr('/'.join(streamname)))
+                    print '-', repr('/'.join(streamname)),'-',
                     st_type = ole.get_type(streamname)
                     if st_type == STGTY_STREAM:
-                        print('size %d' % ole.get_size(streamname))
+                        print 'size %d' % ole.get_size(streamname)
                         # just try to read stream in memory:
                         ole.openstream(streamname)
                     else:
-                        print('NOT a stream : type=%d' % st_type)
-                print('')
+                        print 'NOT a stream : type=%d' % st_type
+                print ''
 
 ##            for streamname in ole.listdir():
 ##                # print name using repr() to convert binary chars to \xNN:
@@ -2014,34 +2009,34 @@ Options:
 ##                print ole.getmtime(streamname)
 ##            print ''
 
-            print('Modification/Creation times of all directory entries:')
+            print 'Modification/Creation times of all directory entries:'
             for entry in ole.direntries:
                 if entry is not None:
-                    print('- %s: mtime=%s ctime=%s' % (entry.name,
-                        entry.getmtime(), entry.getctime()))
-            print('')
+                    print '- %s: mtime=%s ctime=%s' % (entry.name,
+                        entry.getmtime(), entry.getctime())
+            print ''
 
             # parse and display metadata:
             meta = ole.get_metadata()
             meta.dump()
-            print('')
+            print ''
             #[PL] Test a few new methods:
             root = ole.get_rootentry_name()
-            print('Root entry name: "%s"' % root)
+            print 'Root entry name: "%s"' % root
             if ole.exists('worddocument'):
-                print("This is a Word document.")
-                print("type of stream 'WordDocument':", ole.get_type('worddocument'))
-                print("size :", ole.get_size('worddocument'))
+                print "This is a Word document."
+                print "type of stream 'WordDocument':", ole.get_type('worddocument')
+                print "size :", ole.get_size('worddocument')
                 if ole.exists('macros/vba'):
-                    print("This document may contain VBA macros.")
+                    print "This document may contain VBA macros."
 
             # print parsing issues:
-            print('\nNon-fatal issues raised during parsing:')
+            print '\nNon-fatal issues raised during parsing:'
             if ole.parsing_issues:
                 for exctype, msg in ole.parsing_issues:
-                    print('- %s: %s' % (exctype.__name__, msg))
+                    print '- %s: %s' % (exctype.__name__, msg)
             else:
-                print('None')
+                print 'None'
 ##      except IOError, v:
 ##          print "***", "cannot read", file, "-", v
 

--- a/oletools/thirdparty/olefile/olefile2.py
+++ b/oletools/thirdparty/olefile/olefile2.py
@@ -1004,7 +1004,7 @@ class OleFileIO:
     TIFF files).
     """
 
-    def __init__(self, filename = None, raise_defects=DEFECT_FATAL):
+    def     __init__(self, filename = None, raise_defects=DEFECT_FATAL):
         """
         Constructor for OleFileIO class.
 

--- a/oletools/thirdparty/olefile/olefile2.py
+++ b/oletools/thirdparty/olefile/olefile2.py
@@ -209,7 +209,12 @@ __version__ = '0.40py2'
 
 #------------------------------------------------------------------------------
 
-import string, StringIO, struct, array, os.path, sys, datetime
+import string, struct, array, os.path, sys, datetime
+
+try:
+    import StringIO
+except:
+    from _io import StringIO as StringIO
 
 #[PL] Define explicitly the public API to avoid private objects in pydoc:
 __all__ = ['OleFileIO', 'isOleFile']
@@ -222,7 +227,7 @@ elif array.array('I').itemsize == 4:
     # on 64 bits platforms, integers in an array are 32 bits:
     UINT32 = 'I'
 else:
-    raise ValueError, 'Need to fix a bug with 32 bit arrays, please contact author...'
+    raise(ValueError, 'Need to fix a bug with 32 bit arrays, please contact author...')
 
 
 #[PL] These workarounds were inspired from the Path module
@@ -243,7 +248,7 @@ except NameError:
         # is Unicode supported (Python >2.0 or >1.6 ?)
         basestring = (str, unicode)
     except NameError:
-        basestring = str
+       basestring = str
 
 #[PL] Experimental setting: if True, OLE filenames will be kept in Unicode
 # if False (default PIL behaviour), all filenames are converted to Latin-1.
@@ -253,7 +258,7 @@ KEEP_UNICODE_NAMES = False
 # command line to change it.
 DEBUG_MODE = False
 def debug_print(msg):
-    print msg
+    print(msg)
 def debug_pass(msg):
     pass
 debug = debug_pass
@@ -274,15 +279,15 @@ def set_debug_mode(debug_mode):
 MAGIC = '\320\317\021\340\241\261\032\341'
 
 #[PL]: added constants for Sector IDs (from AAF specifications)
-MAXREGSECT = 0xFFFFFFFAL; # maximum SECT
-DIFSECT    = 0xFFFFFFFCL; # (-4) denotes a DIFAT sector in a FAT
-FATSECT    = 0xFFFFFFFDL; # (-3) denotes a FAT sector in a FAT
-ENDOFCHAIN = 0xFFFFFFFEL; # (-2) end of a virtual stream chain
-FREESECT   = 0xFFFFFFFFL; # (-1) unallocated sector
+MAXREGSECT = 0xFFFFFFFA; # maximum SECT
+DIFSECT    = 0xFFFFFFFC; # (-4) denotes a DIFAT sector in a FAT
+FATSECT    = 0xFFFFFFFD; # (-3) denotes a FAT sector in a FAT
+ENDOFCHAIN = 0xFFFFFFFE; # (-2) end of a virtual stream chain
+FREESECT   = 0xFFFFFFFF; # (-1) unallocated sector
 
 #[PL]: added constants for Directory Entry IDs (from AAF specifications)
-MAXREGSID  = 0xFFFFFFFAL; # maximum directory entry ID
-NOSTREAM   = 0xFFFFFFFFL; # (-1) unallocated directory entry
+MAXREGSID  = 0xFFFFFFFA; # maximum directory entry ID
+NOSTREAM   = 0xFFFFFFFF; # (-1) unallocated directory entry
 
 #[PL] object types in storage (from AAF specifications)
 STGTY_EMPTY     = 0 # empty directory entry (according to OpenOffice.org doc)
@@ -392,7 +397,6 @@ def _clsid(clsid):
 
 try:
     # is Unicode supported ?
-    unicode
 
     def _unicode(s, errors='replace'):
         """
@@ -414,7 +418,7 @@ try:
                 return u.encode('latin_1', errors)
         except:
             # there was an error during Unicode to Latin-1 conversion:
-            raise IOError, 'incorrect Unicode name'
+            raise(IOError, 'incorrect Unicode name')
 
 except NameError:
     def _unicode(s, errors='replace'):
@@ -587,14 +591,14 @@ class OleMetadata:
         """
         Dump all metadata, for debugging purposes.
         """
-        print 'Properties from SummaryInformation stream:'
+        print('Properties from SummaryInformation stream:')
         for prop in self.SUMMARY_ATTRIBS:
             value = getattr(self, prop)
-            print '- %s: %s' % (prop, repr(value))
-        print 'Properties from DocumentSummaryInformation stream:'
+            print('- %s: %s' % (prop, repr(value)))
+        print('Properties from DocumentSummaryInformation stream:')
         for prop in self.DOCSUM_ATTRIBS:
             value = getattr(self, prop)
-            print '- %s: %s' % (prop, repr(value))
+            print('- %s: %s' % (prop, repr(value)))
 
 
 #--- _OleStream ---------------------------------------------------------------
@@ -651,7 +655,7 @@ class _OleStream(StringIO.StringIO):
         # This number should (at least) be less than the total number of
         # sectors in the given FAT:
         if nb_sectors > len(fat):
-            raise IOError, 'malformed OLE document, stream too large'
+            raise(IOError, 'malformed OLE document, stream too large')
         # optimization(?): data is first a list of strings, and join() is called
         # at the end to concatenate all in one string.
         # (this may not be really useful with recent Python versions)
@@ -659,10 +663,10 @@ class _OleStream(StringIO.StringIO):
         # if size is zero, then first sector index should be ENDOFCHAIN:
         if size == 0 and sect != ENDOFCHAIN:
             debug('size == 0 and sect != ENDOFCHAIN:')
-            raise IOError, 'incorrect OLE sector index for empty stream'
+            raise(IOError, 'incorrect OLE sector index for empty stream')
         #[PL] A fixed-length for loop is used instead of an undefined while
         # loop to avoid DoS attacks:
-        for i in xrange(nb_sectors):
+        for i in range(nb_sectors):
             # Sector index may be ENDOFCHAIN, but only if size was unknown
             if sect == ENDOFCHAIN:
                 if unknown_size:
@@ -670,7 +674,7 @@ class _OleStream(StringIO.StringIO):
                 else:
                     # else this means that the stream is smaller than declared:
                     debug('sect=ENDOFCHAIN before expected size')
-                    raise IOError, 'incomplete OLE stream'
+                    raise(IOError, 'incomplete OLE stream')
             # sector index should be within FAT:
             if sect<0 or sect>=len(fat):
                 debug('sect=%d (%X) / len(fat)=%d' % (sect, sect, len(fat)))
@@ -680,7 +684,7 @@ class _OleStream(StringIO.StringIO):
 ##                f.write(tmp_data)
 ##                f.close()
 ##                debug('data read so far: %d bytes' % len(tmp_data))
-                raise IOError, 'incorrect OLE FAT, sector index out of range'
+                raise(IOError, 'incorrect OLE FAT, sector index out of range')
             #TODO: merge this code with OleFileIO.getsect() ?
             #TODO: check if this works with 4K sectors:
             try:
@@ -688,7 +692,7 @@ class _OleStream(StringIO.StringIO):
             except:
                 debug('sect=%d, seek=%d, filesize=%d' %
                     (sect, offset+sectorsize*sect, filesize))
-                raise IOError, 'OLE sector index out of range'
+                raise(IOError, 'OLE sector index out of range')
             sector_data = fp.read(sectorsize)
             # [PL] check if there was enough data:
             # Note: if sector is the last of the file, sometimes it is not a
@@ -698,17 +702,17 @@ class _OleStream(StringIO.StringIO):
                 debug('sect=%d / len(fat)=%d, seek=%d / filesize=%d, len read=%d' %
                     (sect, len(fat), offset+sectorsize*sect, filesize, len(sector_data)))
                 debug('seek+len(read)=%d' % (offset+sectorsize*sect+len(sector_data)))
-                raise IOError, 'incomplete OLE sector'
+                raise(IOError, 'incomplete OLE sector')
             data.append(sector_data)
             # jump to next sector in the FAT:
             try:
                 sect = fat[sect]
             except IndexError:
                 # [PL] if pointer is out of the FAT an exception is raised
-                raise IOError, 'incorrect OLE FAT, sector index out of range'
+                raise(IOError, 'incorrect OLE FAT, sector index out of range')
         #[PL] Last sector should be a "end of chain" marker:
         if sect != ENDOFCHAIN:
-            raise IOError, 'incorrect last sector index in OLE stream'
+            raise(IOError, 'incorrect last sector index in OLE stream')
         data = string.join(data, "")
         # Data is truncated to the actual stream size:
         if len(data) >= size:
@@ -722,7 +726,7 @@ class _OleStream(StringIO.StringIO):
         else:
             # read data is less than expected:
             debug('len(data)=%d, size=%d' % (len(data), size))
-            raise IOError, 'OLE stream size is less than declared'
+            raise (IOError, 'OLE stream size is less than declared')
         # when all data is read in memory, StringIO constructor is called
         StringIO.StringIO.__init__(self, data)
         # Then the _OleStream object can be used as a read-only file object.
@@ -829,13 +833,13 @@ class _OleDirectoryEntry:
         # sectors, BUT apparently some implementations set it as 0xFFFFFFFFL, 1
         # or some other value so it cannot be raised as a defect in general:
         if olefile.sectorsize == 512:
-            if sizeHigh != 0 and sizeHigh != 0xFFFFFFFFL:
+            if sizeHigh != 0 and sizeHigh != 0xFFFFFFFF:
                 debug('sectorsize=%d, sizeLow=%d, sizeHigh=%d (%X)' %
                     (olefile.sectorsize, sizeLow, sizeHigh, sizeHigh))
                 olefile._raise_defect(DEFECT_UNSURE, 'incorrect OLE stream size')
             self.size = sizeLow
         else:
-            self.size = sizeLow + (long(sizeHigh)<<32)
+            self.size = sizeLow + (int(sizeHigh)<<32)
         debug(' - size: %d (sizeLow=%d, sizeHigh=%d)' % (self.size, sizeLow, sizeHigh))
 
         self.clsid = _clsid(clsid)
@@ -925,7 +929,7 @@ class _OleDirectoryEntry:
 
     def __cmp__(self, other):
         "Compare entries by name"
-        return cmp(self.name, other.name)
+        return __lt__(self.name, other.name)
         #TODO: replace by the same function as MS implementation ?
         # (order by name length first, then case-insensitive order)
 
@@ -934,12 +938,13 @@ class _OleDirectoryEntry:
         "Dump this entry, and all its subentries (for debug purposes only)"
         TYPES = ["(invalid)", "(storage)", "(stream)", "(lockbytes)",
                  "(property)", "(root)"]
-        print " "*tab + repr(self.name), TYPES[self.entry_type],
+        print(" "*tab + repr(self.name), TYPES[self.entry_type]),
         if self.entry_type in (STGTY_STREAM, STGTY_ROOT):
-            print self.size, "bytes",
-        print
+            print(self.size),\
+            print("bytes"),
+        print("\n")
         if self.entry_type in (STGTY_STORAGE, STGTY_ROOT) and self.clsid:
-            print " "*tab + "{%s}" % self.clsid
+            print(" "*tab + "{%s}" % self.clsid)
 
         for kid in self.kids:
             kid.dump(tab + 2)
@@ -1038,7 +1043,7 @@ class OleFileIO:
         """
         # added by [PL]
         if defect_level >= self._raise_defects_level:
-            raise exception_type, message
+            raise(exception_type, message)
         else:
             # just record the issue, no exception raised:
             self.parsing_issues.append((exception_type, message))
@@ -1148,7 +1153,7 @@ class OleFileIO:
         ) = struct.unpack(fmt_header, header1)
         debug( struct.unpack(fmt_header,    header1))
 
-        if self.Sig != '\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1':
+        if self.Sig != b'\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1':
             # OLE signature should always be present
             self._raise_defect(DEFECT_FATAL, "incorrect OLE signature")
         if self.clsid != '\x00'*16:
@@ -1271,10 +1276,10 @@ class OleFileIO:
             }
         nbsect = len(fat)
         nlines = (nbsect+VPL-1)/VPL
-        print "index",
+        print("index"),
         for i in range(VPL):
             print ("%8X" % i),
-        print ""
+        print("")
         for l in range(nlines):
             index = l*VPL
             print ("%8X:" % (firstindex+index)),
@@ -1289,8 +1294,8 @@ class OleFileIO:
                         nom = "    --->"
                     else:
                         nom = "%8X" % sect
-                print nom,
-            print ""
+                print(nom)
+            print("")
 
 
     def dumpsect(self, sector, firstindex=0):
@@ -1301,10 +1306,10 @@ class OleFileIO:
         tab = array.array(UINT32, sector)
         nbsect = len(tab)
         nlines = (nbsect+VPL-1)/VPL
-        print "index",
+        print("index"),
         for i in range(VPL):
             print ("%8X" % i),
-        print ""
+        print("")
         for l in range(nlines):
             index = l*VPL
             print ("%8X:" % (firstindex+index)),
@@ -1313,8 +1318,8 @@ class OleFileIO:
                     break
                 sect = tab[i]
                 nom = "%8X" % sect
-                print nom,
-            print ""
+                print(nom),
+            print("")
 
     def sect2array(self, sect):
         """
@@ -1398,9 +1403,9 @@ class OleFileIO:
             nb_difat = (self.csectFat-109 + 126)/127
             debug( "nb_difat = %d" % nb_difat )
             if self.csectDif != nb_difat:
-                raise IOError, 'incorrect DIFAT'
+                raise(IOError, 'incorrect DIFAT')
             isect_difat = self.sectDifStart
-            for i in xrange(nb_difat):
+            for i in range(nb_difat):
                 debug( "DIFAT block %d, sector %X" % (i, isect_difat) )
                 #TODO: check if corresponding FAT SID = DIFSECT
                 sector_difat = self.getsect(isect_difat)
@@ -1413,7 +1418,7 @@ class OleFileIO:
             # checks:
             if isect_difat not in [ENDOFCHAIN, FREESECT]:
                 # last DIFAT pointer value must be ENDOFCHAIN or FREESECT
-                raise IOError, 'incorrect end of DIFAT'
+                raise(IOError, 'incorrect end of DIFAT')
 ##          if len(self.fat) != self.num_fat_sectors:
 ##              # FAT should contain num_fat_sectors blocks
 ##              print "FAT length: %d instead of %d" % (len(self.fat), self.num_fat_sectors)
@@ -1653,7 +1658,7 @@ class OleFileIO:
                 if kid.name.lower() == name.lower():
                     break
             else:
-                raise IOError, "file not found"
+                raise(IOError, "file not found")
             node = kid
         return node.sid
 
@@ -1673,7 +1678,7 @@ class OleFileIO:
         sid = self._find(filename)
         entry = self.direntries[sid]
         if entry.entry_type != STGTY_STREAM:
-            raise IOError, "this file is not a stream"
+            raise(IOError, "this file is not a stream")
         return self._open(entry.isectStart, entry.size)
 
 
@@ -1755,7 +1760,7 @@ class OleFileIO:
         entry = self.direntries[sid]
         if entry.entry_type != STGTY_STREAM:
             #TODO: Should it return zero instead of raising an exception ?
-            raise TypeError, 'object is not an OLE stream'
+            raise(TypeError, 'object is not an OLE stream')
         return entry.size
 
 
@@ -1860,12 +1865,12 @@ class OleFileIO:
                     count = i32(s, offset+4)
                     value = _unicode(s[offset+8:offset+8+count*2])
                 elif type == VT_FILETIME:
-                    value = long(i32(s, offset+4)) + (long(i32(s, offset+8))<<32)
+                    value = int(i32(s, offset+4)) + (int(i32(s, offset+8))<<32)
                     # FILETIME is a 64-bit int: "number of 100ns periods
                     # since Jan 1,1601".
                     if convert_time and id not in no_conversion:
                         debug('Converting property #%d to python datetime, value=%d=%fs'
-                                %(id, value, float(value)/10000000L))
+                                %(id, value, float(value)/10000000))
                         # convert FILETIME to Python datetime.datetime
                         # inspired from http://code.activestate.com/recipes/511425-filetime-to-datetime/
                         _FILETIME_null_date = datetime.datetime(1601, 1, 1, 0, 0, 0)
@@ -1874,7 +1879,7 @@ class OleFileIO:
                     else:
                         # legacy code kept for backward compatibility: returns a
                         # number of seconds since Jan 1,1601
-                        value = value / 10000000L # seconds
+                        value = value / 10000000 # seconds
                 elif type == VT_UI1: # 1-byte unsigned integer
                     value = ord(s[offset+4])
                 elif type == VT_CLSID:
@@ -1939,8 +1944,8 @@ if __name__ == "__main__":
 
     # [PL] display quick usage info if launched from command-line
     if len(sys.argv) <= 1:
-        print __doc__
-        print """
+        print(__doc__)
+        print("""
 Launched from command line, this script parses OLE files and prints info.
 
 Usage: olefile2.py [-d] [-c] <file> [file2 ...]
@@ -1948,7 +1953,7 @@ Usage: olefile2.py [-d] [-c] <file> [file2 ...]
 Options:
 -d : debug mode (display a lot of debug information, for developers only)
 -c : check all streams (for debugging purposes)
-"""
+""")
         sys.exit()
 
     check_streams = False
@@ -1965,13 +1970,13 @@ Options:
                 continue
 
             ole = OleFileIO(filename)#, raise_defects=DEFECT_INCORRECT)
-            print "-" * 68
-            print filename
-            print "-" * 68
+            print("-" * 68)
+            print(filename)
+            print("-" * 68)
             ole.dumpdirectory()
             for streamname in ole.listdir():
                 if streamname[-1][0] == "\005":
-                    print streamname, ": properties"
+                    print( "%s : properties" % streamname)
                     props = ole.getproperties(streamname, convert_time=True)
                     props = props.items()
                     props.sort()
@@ -1986,22 +1991,22 @@ Options:
                                 if chr(c) in v:
                                     v = '(binary data)'
                                     break
-                        print "   ", k, v
+                        print("   ", k, v)
 
             if check_streams:
                 # Read all streams to check if there are errors:
-                print '\nChecking streams...'
+                print('\nChecking streams...')
                 for streamname in ole.listdir():
                     # print name using repr() to convert binary chars to \xNN:
-                    print '-', repr('/'.join(streamname)),'-',
+                    print('- %s -' %  repr('/'.join(streamname)))
                     st_type = ole.get_type(streamname)
                     if st_type == STGTY_STREAM:
-                        print 'size %d' % ole.get_size(streamname)
+                        print('size %d' % ole.get_size(streamname))
                         # just try to read stream in memory:
                         ole.openstream(streamname)
                     else:
-                        print 'NOT a stream : type=%d' % st_type
-                print ''
+                        print('NOT a stream : type=%d' % st_type)
+                print('')
 
 ##            for streamname in ole.listdir():
 ##                # print name using repr() to convert binary chars to \xNN:
@@ -2009,34 +2014,34 @@ Options:
 ##                print ole.getmtime(streamname)
 ##            print ''
 
-            print 'Modification/Creation times of all directory entries:'
+            print('Modification/Creation times of all directory entries:')
             for entry in ole.direntries:
                 if entry is not None:
-                    print '- %s: mtime=%s ctime=%s' % (entry.name,
-                        entry.getmtime(), entry.getctime())
-            print ''
+                    print('- %s: mtime=%s ctime=%s' % (entry.name,
+                        entry.getmtime(), entry.getctime()))
+            print('')
 
             # parse and display metadata:
             meta = ole.get_metadata()
             meta.dump()
-            print ''
+            print('')
             #[PL] Test a few new methods:
             root = ole.get_rootentry_name()
-            print 'Root entry name: "%s"' % root
+            print('Root entry name: "%s"' % root)
             if ole.exists('worddocument'):
-                print "This is a Word document."
-                print "type of stream 'WordDocument':", ole.get_type('worddocument')
-                print "size :", ole.get_size('worddocument')
+                print("This is a Word document.")
+                print("type of stream 'WordDocument':", ole.get_type('worddocument'))
+                print("size :", ole.get_size('worddocument'))
                 if ole.exists('macros/vba'):
-                    print "This document may contain VBA macros."
+                    print("This document may contain VBA macros.")
 
             # print parsing issues:
-            print '\nNon-fatal issues raised during parsing:'
+            print('\nNon-fatal issues raised during parsing:')
             if ole.parsing_issues:
                 for exctype, msg in ole.parsing_issues:
-                    print '- %s: %s' % (exctype.__name__, msg)
+                    print('- %s: %s' % (exctype.__name__, msg))
             else:
-                print 'None'
+                print('None')
 ##      except IOError, v:
 ##          print "***", "cannot read", file, "-", v
 

--- a/oletools/thirdparty/tablestream/tablestream.py
+++ b/oletools/thirdparty/tablestream/tablestream.py
@@ -224,7 +224,7 @@ class TableStream(object):
         assert len(row) == self.num_columns
         columns = []
         max_lines = 0
-        for i in xrange(self.num_columns):
+        for i in range(self.num_columns):
             cell = row[i]
             # Convert to string:
             # TODO: handle unicode properly
@@ -233,7 +233,7 @@ class TableStream(object):
                 # encode to UTF8, avoiding errors
                 cell = cell.decode('utf-8', errors='replace')
             else:
-                cell = unicode(cell)
+                cell = cell
             # Wrap cell text according to the column width
             # TODO: use a TextWrapper object for each column instead
             column = textwrap.wrap(cell, width=self.column_width[i])
@@ -241,16 +241,16 @@ class TableStream(object):
             if colors is not None and self.outfile.isatty():
                 color = colors[i]
                 if color:
-                    for j in xrange(len(column)):
+                    for j in range(len(column)):
                         # print '%r: %s' % (column[j], type(column[j]))
                         column[j] = colorclass.Color('{auto%s}%s{/%s}' % (color, column[j], color))
             columns.append(column)
             # determine which column has the highest number of lines
             max_lines = max(len(columns[i]), max_lines)
         # transpose: write output line by line
-        for j in xrange(max_lines):
+        for j in range(max_lines):
             self.write(self.style.vertical_left)
-            for i in xrange(self.num_columns):
+            for i in range(self.num_columns):
                 column = columns[i]
                 if j<len(column):
                     # text to be written


### PR DESCRIPTION
I don't change the regex logical. The code decode VBA macros with bytes and as soon as possible it decode in urtf-8 to match with regex. I modify also the export json because unicode doesn't exist in python 3.5. It's replaced by str and it's not the function to decode. I add the if the json_obj is bytes like hexstring.
