### PR TITLE
Command Line Scripts

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -259,9 +259,15 @@ package_data={
 
 #--- SCRIPTS ------------------------------------------------------------------
 
-# not used for now.
-
-#scripts = ["%s/cherrypy/cherryd" % setupdir]
+entry_points = {
+    'console_scripts': [
+        'olevba=oletools.olevba:main',
+        'mraptor=oletools.mraptor:main',
+        'olebrowse=oletools.olebrowse:main',
+        'oleid=oletools.oleid:main',
+        'pyxswf=oletools.pyxswf:main'
+    ],
+}
 
 
 #=== MAIN =====================================================================
@@ -295,7 +301,7 @@ def main():
         package_data = package_data,
         download_url=download_url,
 #        data_files=data_files,
-#        scripts=scripts,
+        entry_points=entry_points,
     )
 
 


### PR DESCRIPTION
Update of  `setup.py` to provide a command line script:
``` 
$ olevba
$ which olevba
/usr/local/bin/olevba 
```

It's not effective for all scripts as it require a main function entrypoint ```main()``` in the script.