### PR TITLE
Add VirtualAllocEx and RtlMoveMemory to SUSPICIOUS_KEYWORDS

### DIFF
--- a/oletools/olevba.py
+++ b/oletools/olevba.py
@@ -599,6 +599,8 @@ SUSPICIOUS_KEYWORDS = {
     'May detect WinJail Sandbox':
     # ref: http://www.cplusplus.com/forum/windows/96874/
         ('Afx:400000:0',),
+    'Memory manipulation':
+        ('VirtualAllocEx', 'RtlMoveMemory'),
 }
 
 # Regular Expression for a URL:

--- a/oletools/olevba3.py
+++ b/oletools/olevba3.py
@@ -570,6 +570,8 @@ SUSPICIOUS_KEYWORDS = {
     'May detect WinJail Sandbox':
     # ref: http://www.cplusplus.com/forum/windows/96874/
         ('Afx:400000:0',),
+    'Memory manipulation':
+        ('VirtualAllocEx', 'RtlMoveMemory'),
 }
 
 # Regular Expression for a URL:


### PR DESCRIPTION
Add two commonly used memory manipulation Windows API functions to the suspicious keywords list. This has been observed with Vawtrak/Hancitor malicious Word docs.