### PR TITLE
Fixed regex syntax error on line 633 and 2687

### DIFF
--- a/oletools/olevba3.py
+++ b/oletools/olevba3.py
@@ -630,7 +630,7 @@ re_dridex_string = re.compile(r'"[0-9A-Za-z]{20,}"')
 re_nothex_check = re.compile(r'[G-Zg-z]')
 
 # regex to extract printable strings (at least 5 chars) from VBA Forms:
-re_printable_string = re.compile(rb'[\t\r\n\x20-\xFF]{5,}')
+re_printable_string = re.compile(r'[\t\r\n\x20-\xFF]{5,}')
 
 
 # === PARTIAL VBA GRAMMAR ====================================================
@@ -2684,7 +2684,7 @@ class VBA_Parser(object):
                     # read data
                     log.debug('Reading data from stream %r' % d.name)
                     data = ole._open(d.isectStart, d.size).read()
-                    for match in re.finditer(rb'\x00Attribut[^e]', data, flags=re.IGNORECASE):
+                    for match in re.finditer(r'\x00Attribut[^e]', data, flags=re.IGNORECASE):
                         start = match.start() - 3
                         log.debug('Found VBA compressed code at index %X' % start)
                         compressed_code = data[start:]


### PR DESCRIPTION
When I ran python setup.py install inside the oletools directory I received the follow error.

File "/usr/local/lib/python2.7/dist-packages/oletools-0.50a-py2.7.egg/oletools/olevba3.py", line 633
    re_printable_string = re.compile(rb'[\t\r\n\x20-\xFF]{5,}')
                                                             ^
SyntaxError: invalid syntax

After modifying re.compile(rb'[\t\r\n\x20-\xFF]{5,}') to re.compile(r'[\t\r\n\x20-\xFF]{5,}') I received a similar error.

File "/usr/local/lib/python2.7/dist-packages/oletools-0.50a-py2.7.egg/oletools/olevba3.py", line 2687
    for match in re.finditer(rb'\x00Attribut[^e]', data, flags=re.IGNORECASE):
                                                ^
SyntaxError: invalid syntax

I think this 'b' was another unintentional error so I removed it from re.finditer(rb'\x00Attribut[^e]' to re.finditer(r'\x00Attribut[^e]'

I think the inclusion of "rb" might have been due to earlier mention of opening a file in "rb". 

Regards,

Dax
