### PR TITLE
Added ascii char check before length check

### DIFF
--- a/oletools/rtfobj.py
+++ b/oletools/rtfobj.py
@@ -535,6 +535,7 @@ class RtfObjParser(RtfParser):
                 nonhex = re.sub(b'[a-hA-H0-9]', b'', hexdata1)
                 log.debug('Found non-hex chars in hexdata: %r' % nonhex)
             # MS Word accepts an extra hex digit, so we need to trim it if present:
+            hexdata = filter(lambda x: x in "0123456789abcdef", hexdata)
             if len(hexdata) & 1:
                 log.debug('Odd length, trimmed last byte.')
                 hexdata = hexdata[:-1]


### PR DESCRIPTION
cve-2015-1641 document similar to what you've already written about but this one ends up with a rogue '\n' and 'h' characters in them so I added this to fix the problem for me with this document. Hash follows:

93ef5b07453d238bbe8a99172d46ed37a74801c7da2408a9e60fb9e07ae9a029