### PR TITLE
Added zipfile27 package to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,6 +80,7 @@ packages=[
     'oletools.thirdparty.pyparsing',
     'oletools.thirdparty.colorclass',
     'oletools.thirdparty.tablestream',
+    'oletools.thirdparty.zipfile27',
 ]
 ##setupdir = '.'
 ##package_dir={'': setupdir}
@@ -178,6 +179,9 @@ package_data={
         'LICENSE', 'README',
         ],
     'oletools.thirdparty.colorclass': [
+        'LICENSE.txt',
+        ],
+    'oletools.thirdparty.zipfile27': [
         'LICENSE.txt',
         ],
     # 'oletools.thirdparty.tablestream': [


### PR DESCRIPTION
The zipfile27 package isn't installed by setup.py producing the following traceback when olevba is run:

```
Traceback (most recent call last):
  File "/usr/bin/olevba", line 9, in <module>
    load_entry_point('oletools==0.51a1', 'console_scripts', 'olevba')()
  File "/usr/lib/python2.6/site-packages/pkg_resources/__init__.py", line 558, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/usr/lib/python2.6/site-packages/pkg_resources/__init__.py", line 2682, in load_entry_point
    return ep.load()
  File "/usr/lib/python2.6/site-packages/pkg_resources/__init__.py", line 2355, in load
    return self.resolve()
  File "/usr/lib/python2.6/site-packages/pkg_resources/__init__.py", line 2361, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/usr/lib/python2.6/site-packages/oletools-0.51a1-py2.6.egg/oletools/olevba.py", line 279, in <module>
    from thirdparty.zipfile27 import is_zipfile
ImportError: No module named zipfile27
```

I added the package so it is installed. 