### PR TITLE
Clamp num_props to prevent excessive resource usage

### DIFF
--- a/oletools/thirdparty/olefile/olefile.py
+++ b/oletools/thirdparty/olefile/olefile.py
@@ -2201,7 +2201,10 @@ class OleFileIO:
             self._raise_defect(DEFECT_INCORRECT, msg, type(exc))
             return data
 
-        for i in range(num_props):
+        # clamp num_props based on the data length
+        num_props = min(num_props, len(s) / 8)
+        
+        for i in xrange(num_props):
             property_id = 0 # just in case of an exception
             try:
                 property_id = i32(s, 8+i*8)


### PR DESCRIPTION
A large num_props value will cause memory bloat (via the range usage) and potentially billions of useless logs in relaxed mode.  Clamp it to a value that has a reasonable chance of working without generating exceptions.