### PR TITLE
olevba: quit if file is an encrypted OOXML file

### DIFF
--- a/oletools/olevba3.py
+++ b/oletools/olevba3.py
@@ -197,6 +197,7 @@ from __future__ import print_function
 # 2017-06-08       PL: - fixed issue #122 Chr() with negative numbers
 # 2017-06-15       PL: - deobfuscation line by line to handle large files
 # 2017-07-11 v0.52 PL: - raise exception instead of sys.exit (issue #180)
+# 2017-09-11       SA: - detect OpenXML encryption
 # 2018-03-19       PL: - removed pyparsing from the thirdparty subfolder
 
 __version__ = '0.52.3'
@@ -460,15 +461,16 @@ class UnexpectedDataError(OlevbaBaseException):
 #--- CONSTANTS ----------------------------------------------------------------
 
 # return codes
-RETURN_OK             = 0
-RETURN_WARNINGS       = 1  # (reserved, not used yet)
-RETURN_WRONG_ARGS     = 2  # (fixed, built into optparse)
-RETURN_FILE_NOT_FOUND = 3
-RETURN_XGLOB_ERR      = 4
-RETURN_OPEN_ERROR     = 5
-RETURN_PARSE_ERROR    = 6
-RETURN_SEVERAL_ERRS   = 7
-RETURN_UNEXPECTED     = 8
+RETURN_OK              = 0
+RETURN_WARNINGS        = 1  # (reserved, not used yet)
+RETURN_WRONG_ARGS      = 2  # (fixed, built into optparse)
+RETURN_FILE_NOT_FOUND  = 3
+RETURN_XGLOB_ERR       = 4
+RETURN_OPEN_ERROR      = 5
+RETURN_PARSE_ERROR     = 6
+RETURN_SEVERAL_ERRS    = 7
+RETURN_UNEXPECTED      = 8
+RETURN_ENCRYPTED_OOXML = 9
 
 # MAC codepages (from http://stackoverflow.com/questions/1592925/decoding-mac-os-text-in-python)
 MAC_CODEPAGES = {
@@ -2338,6 +2340,12 @@ class VBA_Parser(object):
 
             # if this worked, try whether it is a ppt file (special ole file)
             self.open_ppt()
+
+            # check if this is an encrypted OpenXML file and quit if it is
+            if self.ole_file.exists('EncryptionInfo'):
+                log.info('File is an encrypted OpenXML file %r' % (self.filename))
+                sys.exit(RETURN_ENCRYPTED_OOXML)
+
         if self.type is None and is_zipfile(_file):
             # Zip file, which may be an OpenXML document
             self.open_openxml(_file)

--- a/tests/olevba/test_issue_194.py
+++ b/tests/olevba/test_issue_194.py
@@ -1,0 +1,28 @@
+""" Tests if olevba detects encrypted documents
+"""
+
+import unittest, sys, os
+
+from os.path import join
+from tests.test_utils import DATA_BASE_DIR
+
+if sys.version_info[0] <= 2:
+    from oletools import olevba
+else:
+    from oletools import olevba3 as olevba
+
+class TestEncryptedDocumentDetection(unittest.TestCase):
+    def test_encrypted_document_detection(self):
+        """ Run olevba and check if the return code indicates encryption """
+        filename = join(DATA_BASE_DIR, 'basic/encrypted.docx')
+
+        try:
+            return_code = olevba.main([filename])
+        except SystemExit as se:
+            return_code = se.code
+
+        self.assertEqual(return_code, olevba.RETURN_ENCRYPTED_OOXML)
+
+# just in case somebody calls this file as a script
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This is similar to what was done in #194 for oleid, except that it returns a special code for scripts and tools that use olevba to scan files.