### PR TITLE
Adds an additional check to detect DDE

### DIFF
--- a/oletools/msodde.py
+++ b/oletools/msodde.py
@@ -80,7 +80,7 @@ NS_WORD = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main'
 
 # XML tag for 'w:instrText'
 TAG_W_INSTRTEXT = '{%s}instrText' % NS_WORD
-
+TAG_W_FLDSIMPLE = '{%s}fldSimple' % NS_WORD
 
 # === FUNCTIONS ==============================================================
 
@@ -111,6 +111,13 @@ def process_file(filepath):
         # concatenate the text of the field, if present:
         if elem.text is not None:
             text += elem.text
+
+    for elem in root.iter(TAG_W_FLDSIMPLE):
+        # concatenate the attribute of the field, if present:
+        if elem.attrib is not None:
+            text += elem.attrib['{http://schemas.openxmlformats.org/wordprocessingml/2006/main}instr']
+    
+
     return text
 
 

--- a/oletools/msodde.py
+++ b/oletools/msodde.py
@@ -81,6 +81,7 @@ NS_WORD = 'http://schemas.openxmlformats.org/wordprocessingml/2006/main'
 # XML tag for 'w:instrText'
 TAG_W_INSTRTEXT = '{%s}instrText' % NS_WORD
 TAG_W_FLDSIMPLE = '{%s}fldSimple' % NS_WORD
+TAG_W_INSTRATTR= '{%s}instr' % NS_WORD
 
 # === FUNCTIONS ==============================================================
 
@@ -115,7 +116,7 @@ def process_file(filepath):
     for elem in root.iter(TAG_W_FLDSIMPLE):
         # concatenate the attribute of the field, if present:
         if elem.attrib is not None:
-            text += elem.attrib['{http://schemas.openxmlformats.org/wordprocessingml/2006/main}instr']
+            text += elem.attrib[TAG_W_INSTRATTR]
     
 
     return text


### PR DESCRIPTION
DDE / DDEAUTO can also be specified with  
```
<w:fldSimple w:instr='DDE "C:\\WINDOWS\\system32\\cmd.exe" "/k powershell.exe"' w:dirty="true">
    <w:r>
        <w:t>Pew</w:t>
    </w:r>
</w:fldSimple>
```

This adds some additional parsing to extract the link if it is inside a ```w:fldSimple``` element