### PR TITLE
Minor msodde fixes

### DIFF
--- a/oletools/msodde.py
+++ b/oletools/msodde.py
@@ -285,8 +285,7 @@ def process_ole_stream(stream):
     log.debug('Checked {0} characters, found {1} fields'
               .format(idx, len(result_parts)))
 
-    # copy behaviour of process_xml: Just concatenate unicode strings
-    return u''.join(result_parts)
+    return result_parts
 
 
 def process_ole_storage(ole):
@@ -296,7 +295,7 @@ def process_ole_storage(ole):
         st_type = ole.get_type(st)
         if st_type == olefile.STGTY_STREAM:      # a stream
             stream = None
-            links = ''
+            links = []
             try:
                 stream = ole.openstream(st)
                 log.debug('Checking stream {0}'.format(st))
@@ -307,7 +306,7 @@ def process_ole_storage(ole):
                 if stream:
                     stream.close()
             if links:
-                results.append(links)
+                results.extend(links)
         elif st_type == olefile.STGTY_STORAGE:   # a storage
             log.debug('Checking storage {0}'.format(st))
             links = process_ole_storage(st)
@@ -331,6 +330,8 @@ def process_ole(filepath):
     log.debug('process_ole')
     ole = olefile.OleFileIO(filepath, path_encoding=None)
     text_parts = process_ole_storage(ole)
+
+    # mimic behaviour of process_openxml: combine links to single text string
     return u'\n'.join(text_parts)
 
 

--- a/oletools/msodde.py
+++ b/oletools/msodde.py
@@ -109,8 +109,8 @@ Please report any issue at https://github.com/decalage2/oletools/issues
 BANNER_JSON = dict(type='meta', version=__version__, name='msodde',
                    link='http://decalage.info/python/oletools',
                    message='THIS IS WORK IN PROGRESS - Check updates regularly! '
-                            'Please report any issue at '
-                            'https://github.com/decalage2/oletools/issues')
+                           'Please report any issue at '
+                           'https://github.com/decalage2/oletools/issues')
 
 # === LOGGING =================================================================
 
@@ -231,6 +231,7 @@ def existing_file(filename):
 
 
 def process_args(cmd_line_args=None):
+    """ parse command line arguments (given ones or per default sys.argv) """
     parser = ArgParserWithBanner(description='A python tool to detect and extract DDE links in MS Office files')
     parser.add_argument("filepath", help="path of the file to be analyzed",
                         type=existing_file, metavar='FILE')
@@ -339,7 +340,7 @@ def process_ole_stream(stream):
 
 
 def process_ole_storage(ole):
-    """ process a "directory" inside an ole stream """
+    """ process a "directory" inside an ole file; recursive """
     results = []
     for st in ole.listdir(streams=True, storages=True):
         st_type = ole.get_type(st)
@@ -350,7 +351,7 @@ def process_ole_storage(ole):
                 stream = ole.openstream(st)
                 log.debug('Checking stream {0}'.format(st))
                 links = process_ole_stream(stream)
-            except:
+            except Exception:
                 raise
             finally:
                 if stream:
@@ -370,7 +371,7 @@ def process_ole_storage(ole):
 
 
 def process_ole(filepath):
-    """ 
+    """
     find dde links in ole file
 
     like process_xml, returns a concatenated unicode string of dde links or
@@ -524,7 +525,8 @@ def main(cmd_line_args=None):
 
     if args.json:
         for line in text.splitlines():
-            jout.append(dict(type='dde-link', link=line.strip()))
+            if line.strip():
+                jout.append(dict(type='dde-link', link=line.strip()))
         json.dump(jout, sys.stdout, check_circular=False, indent=4)
         print()   # add a newline after closing "]"
         return return_code  # required if we catch an exception in json-mode

--- a/oletools/msodde.py
+++ b/oletools/msodde.py
@@ -78,6 +78,13 @@ import sys
 import json
 import logging
 
+# little hack to allow absolute imports even if oletools is not installed
+# Copied from olevba.py
+_thismodule_dir = os.path.normpath(os.path.abspath(os.path.dirname(__file__)))
+_parent_dir = os.path.normpath(os.path.join(_thismodule_dir, '..'))
+if not _parent_dir in sys.path:
+    sys.path.insert(0, _parent_dir)
+
 from oletools.thirdparty import olefile
 
 # === PYTHON 2+3 SUPPORT ======================================================


### PR DESCRIPTION
Lots of minor fixes and improvements to msodde.py:
(did not touch other user's code parts except where necessary)

- replace #print(..) with either log.debug(..) or remove it
- warn if combining --json with -ldebug
- delay combining dde-links to single text just like process_xml
- fix print(..) of unicode in dde-links of re-directing output or piping it to other command
- fix some complaints from pylint: base except, whitespace, missing docs
- remove empty dde-links from result output
- copy hack from olevba.py to run without installing

Some of this is required for adding more unittests (see next pull request)