### PR TITLE
Run tests on python3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 
 python:
   - "2.7"
+  - "3.6"
+  - "nightly"
 cache: pip
 script:
   - python setup.py test

--- a/oletools/olevba3.py
+++ b/oletools/olevba3.py
@@ -3137,9 +3137,12 @@ class VBA_Parser_CLI(VBA_Parser):
             if self.detect_vba_macros():
                 for (subfilename, stream_path, vba_filename, vba_code) in self.extract_all_macros():
                     curr_macro = {}
+                    if isinstance(vba_code, bytes):
+                        vba_code = vba_code.decode('utf-8', 'backslashreplace')
+
                     if hide_attributes:
                         # hide attribute lines:
-                        vba_code_filtered = filter_vba(vba_code.decode('utf-8','backslashreplace'))
+                        vba_code_filtered = filter_vba(vba_code)
                     else:
                         vba_code_filtered = vba_code
 


### PR DESCRIPTION
I've changed the Travis configuration to also run tests on Python 3 and newer versions.

olevba3 required a little extra check so [one test from test_output.py](https://github.com/decalage2/oletools/blob/1b7f44d128dcb623ec27e3d042d4e3ba858470dd/tests/json/test_output.py#L83) could pass.