### PR TITLE
Olevba skip rtf

### DIFF
--- a/oletools/olevba.py
+++ b/oletools/olevba.py
@@ -293,6 +293,7 @@ from oletools.thirdparty.pyparsing.pyparsing import \
         infixNotation, ParserElement
 from oletools import ppt_parser
 from oletools import oleform
+from oletools import rtfobj
 
 
 # monkeypatch email to fix issue #32:

--- a/oletools/olevba.py
+++ b/oletools/olevba.py
@@ -2354,6 +2354,13 @@ class VBA_Parser(object):
                 self.open_mht(data)
         #TODO: handle exceptions
         #TODO: Excel 2003 XML
+            # Check whether this is rtf
+            if rtfobj.is_rtf(data, treat_str_as_data=True):
+                # Ignore RTF since it contains no macros and methods in here will not find macros
+                # in embedded objects. run rtfobj and repeat on its output.
+                msg = '%s is RTF, need to run rtfobj.py and find VBA Macros in its output.' % self.filename
+                log.info(msg)
+                raise FileOpenError(msg)
             # Check if this is a plain text VBA or VBScript file:
             # To avoid scanning binary files, we simply check for some control chars:
             if self.type is None and b'\x00' not in data:

--- a/oletools/olevba3.py
+++ b/oletools/olevba3.py
@@ -237,6 +237,7 @@ import os
 import logging
 import struct
 from _io import StringIO,BytesIO
+from oletools import rtfobj
 import math
 import zipfile
 import re
@@ -2361,6 +2362,13 @@ class VBA_Parser(object):
                 self.open_mht(data)
         #TODO: handle exceptions
         #TODO: Excel 2003 XML
+            # Check whether this is rtf
+            if rtfobj.is_rtf(data, treat_str_as_data=True):
+                # Ignore RTF since it contains no macros and methods in here will not find macros
+                # in embedded objects. run rtfobj and repeat on its output.
+                msg = '%s is RTF, need to run rtfobj.py and find VBA Macros in its output.' % self.filename
+                log.info(msg)
+                raise FileOpenError(msg)
             # Check if this is a plain text VBA or VBScript file:
             # To avoid scanning binary files, we simply check for some control chars:
             if self.type is None and b'\x00' not in data:

--- a/oletools/rtfobj.py
+++ b/oletools/rtfobj.py
@@ -701,7 +701,7 @@ def is_rtf(arg, treat_str_as_data=False):
     if isinstance(arg, str):      # could be bytes, but we assume file name
         if treat_str_as_data:
             try:
-                return arg[:magic_len].encode('ascii', error='strict').lower()\
+                return arg[:magic_len].encode('ascii', errors='strict').lower()\
                     == RTF_MAGIC
             except UnicodeError:
                 return False

--- a/oletools/rtfobj.py
+++ b/oletools/rtfobj.py
@@ -689,14 +689,11 @@ def is_rtf(arg, treat_str_as_data=False):
     """
     magic_len = len(RTF_MAGIC)
     if isinstance(arg, UNICODE_TYPE):
-        print('test file name')
         with open(arg, 'rb') as reader:
             return reader.read(len(RTF_MAGIC)).lower() == RTF_MAGIC
     if isinstance(arg, bytes) and not isinstance(arg, str):  # only in PY3
-        print('test byte array')
         return arg[:magic_len].lower() == RTF_MAGIC
     if isinstance(arg, bytearray):
-        print('test byte array')
         return arg[:magic_len].lower() == RTF_MAGIC
     if isinstance(arg, str):      # could be bytes, but we assume file name
         if treat_str_as_data:
@@ -706,17 +703,13 @@ def is_rtf(arg, treat_str_as_data=False):
             except UnicodeError:
                 return False
         else:
-            print('test file name')
             with open(arg, 'rb') as reader:
                 return reader.read(len(RTF_MAGIC)).lower() == RTF_MAGIC
     if hasattr(arg, 'read'):      # a stream (i.e. file-like object)
-        print('test stream')
         return arg.read(len(RTF_MAGIC)).lower() == RTF_MAGIC
     if isinstance(arg, (list, tuple)):
-        print('test list/tuple')
         iter_arg = iter(arg)
     else:
-        print('test iterable')
         iter_arg = arg
 
     # check iterable

--- a/tests/json/test_output.py
+++ b/tests/json/test_output.py
@@ -1,8 +1,8 @@
 """ Test validity of json output
 
 Some scripts have a json output flag. Verify that at default log levels output
-can be captured as-is and parsed by a json parser -- at least if the scripts
-return 0
+can be captured as-is and parsed by a json parser -- checking the return code
+if desired.
 """
 
 import unittest
@@ -20,7 +20,11 @@ else:
 
 
 class TestValidJson(unittest.TestCase):
-    """ Ensure that script output is valid json (if return code is 0) """
+    """
+    Ensure that script output is valid json.
+    If check_return_code is True we also ignore the output
+    of runs that didn't succeed.
+    """
 
     def iter_test_files(self):
         """ Iterate over all test files in DATA_BASE_DIR """

--- a/tests/json/test_output.py
+++ b/tests/json/test_output.py
@@ -28,7 +28,7 @@ class TestValidJson(unittest.TestCase):
             for filename in filenames:
                 yield join(dirpath, filename)
 
-    def run_and_parse(self, program, args, print_output=False):
+    def run_and_parse(self, program, args, print_output=False, check_return_code=True):
         """ run single program with single file and parse output """
         return_code = None
         with OutputCapture() as capturer:       # capture stdout
@@ -38,7 +38,7 @@ class TestValidJson(unittest.TestCase):
                 return_code = 1   # would result in non-zero exit
             except SystemExit as se:
                 return_code = se.code or 0   # se.code can be None
-        if return_code is not 0:
+        if check_return_code and return_code is not 0:
             if print_output:
                 print('Command failed ({0}) -- not parsing output'
                       .format(return_code))
@@ -82,7 +82,8 @@ class TestValidJson(unittest.TestCase):
     def test_olevba_recurse(self):
         """ Test olevba.py with -r """
         json_data = self.run_and_parse(olevba.main,
-                                       ['-j', '-r', join(DATA_BASE_DIR, '*')])
+                                       ['-j', '-r', join(DATA_BASE_DIR, '*')],
+                                       check_return_code=False)
         self.assertNotEqual(len(json_data), 0,
                             msg='olevba[3] returned non-zero or no output')
         self.assertNotEqual(json_data[-1]['n_processed'], 0,

--- a/tests/rtfobj/test_is_rtf.py
+++ b/tests/rtfobj/test_is_rtf.py
@@ -23,9 +23,9 @@ class TestIsRtf(unittest.TestCase):
 
     def test_bytes(self):
         """ test that is_rtf works with bytearray """
-        self.assertTrue(is_rtf(RTF_MAGIC + b'asasdffdfasdfasdfasdfasdf', True), True)
-        self.assertTrue(is_rtf(RTF_MAGIC.upper() + b'asdffasdfasdasdff', True), True)
-        self.assertFalse(is_rtf(b'asdfasdfasdfasdfasdfasdasdfffsdfsdfa', True), True)
+        self.assertTrue(is_rtf(RTF_MAGIC + b'asasdffdfasdfasdfasdfasdf', True))
+        self.assertTrue(is_rtf(RTF_MAGIC.upper() + b'asdffasdfasdasdff', True))
+        self.assertFalse(is_rtf(b'asdfasdfasdfasdfasdfasdasdfffsdfsdfa', True))
 
     def test_tuple(self):
         """ test that is_rtf works with byte tuples """

--- a/tests/rtfobj/test_is_rtf.py
+++ b/tests/rtfobj/test_is_rtf.py
@@ -23,9 +23,9 @@ class TestIsRtf(unittest.TestCase):
 
     def test_bytes(self):
         """ test that is_rtf works with bytearray """
-        self.assertTrue(is_rtf(RTF_MAGIC + b'asasdffdfasdfasdfasdfasdf'), True)
-        self.assertTrue(is_rtf(RTF_MAGIC.upper() + b'asdffasdfasdasdff'), True)
-        self.assertFalse(is_rtf(b'asdfasdfasdfasdfasdfasdasdfffsdfsdfa'), True)
+        self.assertTrue(is_rtf(RTF_MAGIC + b'asasdffdfasdfasdfasdfasdf', True), True)
+        self.assertTrue(is_rtf(RTF_MAGIC.upper() + b'asdffasdfasdasdff', True), True)
+        self.assertFalse(is_rtf(b'asdfasdfasdfasdfasdfasdasdfffsdfsdfa', True), True)
 
     def test_tuple(self):
         """ test that is_rtf works with byte tuples """

--- a/tests/rtfobj/test_is_rtf.py
+++ b/tests/rtfobj/test_is_rtf.py
@@ -1,0 +1,69 @@
+""" Test rtfobj.is_rtf """
+
+from __future__ import print_function
+
+import unittest
+from os.path import join
+from os import walk
+
+from oletools.rtfobj import is_rtf, RTF_MAGIC
+
+# Directory with test data, independent of current working directory
+from tests.test_utils import DATA_BASE_DIR
+
+
+class TestIsRtf(unittest.TestCase):
+    """ Tests rtfobj.is_rtf """
+
+    def test_bytearray(self):
+        """ test that is_rtf works with bytearray """
+        self.assertTrue(is_rtf(bytearray(RTF_MAGIC + b'asdfasdfasdfasdfasdf')))
+        self.assertTrue(is_rtf(bytearray(RTF_MAGIC.upper() + b'asdfasdasdff')))
+        self.assertFalse(is_rtf(bytearray(b'asdfasdfasdfasdfasdfasdfsdfsdfa')))
+
+    def test_bytes(self):
+        """ test that is_rtf works with bytearray """
+        self.assertTrue(is_rtf(RTF_MAGIC + b'asasdffdfasdfasdfasdfasdf'), True)
+        self.assertTrue(is_rtf(RTF_MAGIC.upper() + b'asdffasdfasdasdff'), True)
+        self.assertFalse(is_rtf(b'asdfasdfasdfasdfasdfasdasdfffsdfsdfa'), True)
+
+    def test_tuple(self):
+        """ test that is_rtf works with byte tuples """
+        data = tuple(byte_char for byte_char in RTF_MAGIC + b'asdfasfadfdfsdf')
+        self.assertTrue(is_rtf(data))
+
+        data = tuple(byte_char for byte_char in RTF_MAGIC.upper() + b'asfasdf')
+        self.assertTrue(is_rtf(data))
+
+        data = tuple(byte_char for byte_char in b'asdfasfassdfsdsfeereasdfwdf')
+        self.assertFalse(is_rtf(data))
+
+    def test_iterable(self):
+        """ test that is_rtf works with byte iterables """
+        data = (byte_char for byte_char in RTF_MAGIC + b'asdfasfasasdfasdfddf')
+        self.assertTrue(is_rtf(data))
+
+        data = (byte_char for byte_char in RTF_MAGIC.upper() + b'asdfassfasdf')
+        self.assertTrue(is_rtf(data))
+
+        data = (byte_char for byte_char in b'asdfasfasasdfasdfasdfsdfdwerwedf')
+        self.assertFalse(is_rtf(data))
+
+    def test_files(self):
+        """ test on real files """
+        for base_dir, _, files in walk(DATA_BASE_DIR):
+            for filename in files:
+                full_path = join(base_dir, filename)
+                expect = filename.endswith('.rtf')
+                self.assertEqual(is_rtf(full_path), expect,
+                                 'is_rtf({0}) did not return {1}'
+                                 .format(full_path, expect))
+                with open(full_path, 'rb') as handle:
+                    self.assertEqual(is_rtf(handle), expect,
+                                    'is_rtf(open({0})) did not return {1}'
+                                    .format(full_path, expect))
+
+
+# just in case somebody calls this file as a script
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
olevba[3] often takes ages to scan RTF because it handles them like TXT and finds lots of bogus "hex strings" that are actually only regular rtf commands.

This is a waste of time since RTF itself cannot contain VBA/Macro code. The only way to carry bad stuff for RTF is to have it embedded as an own file, for which rtfdump is the right utility.

Therefore, we suggest skipping RTF files in olevba[3] with a message saying that rtfobj should be run instead.

Created a general-purpose check function is_rtf in rtfobj, based also on http://www.decalage.info/rtf_tricks