### PR TITLE
rtfobj: remove check for uppercased RTF magic

### DIFF
--- a/oletools/rtfobj.py
+++ b/oletools/rtfobj.py
@@ -690,35 +690,36 @@ def is_rtf(arg, treat_str_as_data=False):
     magic_len = len(RTF_MAGIC)
     if isinstance(arg, UNICODE_TYPE):
         with open(arg, 'rb') as reader:
-            return reader.read(len(RTF_MAGIC)).lower() == RTF_MAGIC
+            return reader.read(len(RTF_MAGIC)) == RTF_MAGIC
     if isinstance(arg, bytes) and not isinstance(arg, str):  # only in PY3
-        return arg[:magic_len].lower() == RTF_MAGIC
+        return arg[:magic_len] == RTF_MAGIC
     if isinstance(arg, bytearray):
-        return arg[:magic_len].lower() == RTF_MAGIC
+        return arg[:magic_len] == RTF_MAGIC
     if isinstance(arg, str):      # could be bytes, but we assume file name
         if treat_str_as_data:
             try:
-                return arg[:magic_len].encode('ascii', errors='strict').lower()\
+                return arg[:magic_len].encode('ascii', errors='strict')\
                     == RTF_MAGIC
             except UnicodeError:
                 return False
         else:
             with open(arg, 'rb') as reader:
-                return reader.read(len(RTF_MAGIC)).lower() == RTF_MAGIC
+                return reader.read(len(RTF_MAGIC)) == RTF_MAGIC
     if hasattr(arg, 'read'):      # a stream (i.e. file-like object)
-        return arg.read(len(RTF_MAGIC)).lower() == RTF_MAGIC
+        return arg.read(len(RTF_MAGIC)) == RTF_MAGIC
     if isinstance(arg, (list, tuple)):
         iter_arg = iter(arg)
     else:
         iter_arg = arg
 
     # check iterable
-    for magic_byte, upper_cased in zip(RTF_MAGIC, RTF_MAGIC.upper()):
+    for magic_byte in zip(RTF_MAGIC):
         try:
-            if next(iter_arg) not in (magic_byte, upper_cased):
+            if next(iter_arg) not in magic_byte:
                 return False
         except StopIteration:
             return False
+
     return True  # checked the complete magic without returning False --> match
 
 

--- a/tests/json/test_output.py
+++ b/tests/json/test_output.py
@@ -26,7 +26,8 @@ class TestValidJson(unittest.TestCase):
     of runs that didn't succeed.
     """
 
-    def iter_test_files(self):
+    @staticmethod
+    def iter_test_files():
         """ Iterate over all test files in DATA_BASE_DIR """
         for dirpath, _, filenames in os.walk(DATA_BASE_DIR):
             for filename in filenames:
@@ -34,7 +35,6 @@ class TestValidJson(unittest.TestCase):
 
     def run_and_parse(self, program, args, print_output=False, check_return_code=True):
         """ run single program with single file and parse output """
-        return_code = None
         with OutputCapture() as capturer:       # capture stdout
             try:
                 return_code = program(args)

--- a/tests/rtfobj/test_is_rtf.py
+++ b/tests/rtfobj/test_is_rtf.py
@@ -60,8 +60,8 @@ class TestIsRtf(unittest.TestCase):
                                  .format(full_path, expect))
                 with open(full_path, 'rb') as handle:
                     self.assertEqual(is_rtf(handle), expect,
-                                    'is_rtf(open({0})) did not return {1}'
-                                    .format(full_path, expect))
+                                     'is_rtf(open({0})) did not return {1}'
+                                     .format(full_path, expect))
 
 
 # just in case somebody calls this file as a script

--- a/tests/rtfobj/test_is_rtf.py
+++ b/tests/rtfobj/test_is_rtf.py
@@ -18,13 +18,13 @@ class TestIsRtf(unittest.TestCase):
     def test_bytearray(self):
         """ test that is_rtf works with bytearray """
         self.assertTrue(is_rtf(bytearray(RTF_MAGIC + b'asdfasdfasdfasdfasdf')))
-        self.assertTrue(is_rtf(bytearray(RTF_MAGIC.upper() + b'asdfasdasdff')))
+        self.assertFalse(is_rtf(bytearray(RTF_MAGIC.upper() + b'asdfasdasdff')))
         self.assertFalse(is_rtf(bytearray(b'asdfasdfasdfasdfasdfasdfsdfsdfa')))
 
     def test_bytes(self):
         """ test that is_rtf works with bytearray """
         self.assertTrue(is_rtf(RTF_MAGIC + b'asasdffdfasdfasdfasdfasdf', True))
-        self.assertTrue(is_rtf(RTF_MAGIC.upper() + b'asdffasdfasdasdff', True))
+        self.assertFalse(is_rtf(RTF_MAGIC.upper() + b'asdffasdfasdasdff', True))
         self.assertFalse(is_rtf(b'asdfasdfasdfasdfasdfasdasdfffsdfsdfa', True))
 
     def test_tuple(self):
@@ -33,7 +33,7 @@ class TestIsRtf(unittest.TestCase):
         self.assertTrue(is_rtf(data))
 
         data = tuple(byte_char for byte_char in RTF_MAGIC.upper() + b'asfasdf')
-        self.assertTrue(is_rtf(data))
+        self.assertFalse(is_rtf(data))
 
         data = tuple(byte_char for byte_char in b'asdfasfassdfsdsfeereasdfwdf')
         self.assertFalse(is_rtf(data))
@@ -44,7 +44,7 @@ class TestIsRtf(unittest.TestCase):
         self.assertTrue(is_rtf(data))
 
         data = (byte_char for byte_char in RTF_MAGIC.upper() + b'asdfassfasdf')
-        self.assertTrue(is_rtf(data))
+        self.assertFalse(is_rtf(data))
 
         data = (byte_char for byte_char in b'asdfasfasasdfasdfasdfsdfdwerwedf')
         self.assertFalse(is_rtf(data))


### PR DESCRIPTION
Following the discussion on #254, this PR removes checks for
uppercased RTF magic since neither Word nor Wordpad accept
those.

Some changes related to PEP8 style were also made.