### PR TITLE
Fix always enabled logging in PptParser.

### DIFF
--- a/oletools/olevba3.py
+++ b/oletools/olevba3.py
@@ -2584,7 +2584,6 @@ class VBA_Parser(object):
         """
 
         log.info('Check whether OLE file is PPT')
-        ppt_parser.enable_logging()
         try:
             ppt = ppt_parser.PptParser(self.ole_file, fast_fail=True)
             for vba_data in ppt.iter_vba_data():


### PR DESCRIPTION
When using VBA_Parser from olevba3.py, ppt_parser logging is always enabled. This is similar to issue #154, although enable_logging() method is already implemented and ppt_parser logging is handled there, so just remove enable_logging from VBA_Parser.open_ppt().