### PR TITLE
Csv formula extension

### DIFF
--- a/oletools/msodde.py
+++ b/oletools/msodde.py
@@ -833,7 +833,8 @@ def process_rtf(file_handle, field_filter_mode=None):
 CSV_SMALL_THRESH = 1024
 
 # format of dde link: program-name | arguments ! unimportant
-CSV_DDE_FORMAT = re.compile(r'\s*=(.+)\|(.+)!(.*)\s*')
+# can be enclosed in "", prefixed with + or = or - or cmds like @SUM(...)
+CSV_DDE_FORMAT = re.compile(r'\s*"?[=+-@](.+)\|(.+)!(.*)\s*')
 
 # allowed delimiters (python sniffer would use nearly any char). Taken from
 # https://data-gov.tw.rpi.edu/wiki/CSV_files_use_delimiters_other_than_commas

--- a/tests/msodde/test_csv.py
+++ b/tests/msodde/test_csv.py
@@ -131,6 +131,17 @@ class TestCSV(unittest.TestCase):
         self.assertTrue(have_start_line)  # ensure output was complete
         return result
 
+    def test_regex(self):
+        """ check that regex captures other ways to include dde commands
+        
+        from http://www.exploresecurity.com/from-csv-to-cmd-to-qwerty/ and/or
+        https://www.contextis.com/blog/comma-separated-vulnerabilities
+        """
+        kernel = "cmd|'/c calc'!A0"
+        for wrap in '={0}', '@SUM({0})', '"={0}"', '+{0}', '-{0}':
+            cmd = wrap.format(kernel)
+            self.assertNotEqual(msodde.CSV_DDE_FORMAT.match(cmd), None)
+
 
 # just in case somebody calls this file as a script
 if __name__ == '__main__':


### PR DESCRIPTION
Extend formula to find DDE-Links in CSV as described in issue #259 . Added simple unittest.

The resulting output will not be as perfectly cleaned as before (may contain the "SUM(" or the wrapping ""), but all samples mentioned in issue are matched by regex.