### PR TITLE
Improve detect_flash Python 3 compatibility

### DIFF
--- a/oletools/oleid.py
+++ b/oletools/oleid.py
@@ -117,7 +117,7 @@ def detect_flash (data):
         # Read Header
         header = data[start:start+3]
         # Read Version
-        ver = struct.unpack('<b', data[start+3])[0]
+        ver = struct.unpack('<b', data[start+3:start+4])[0]
         # Error check for version above 20
         #TODO: is this accurate? (check SWF specifications)
         if ver > 20:


### PR DESCRIPTION
Here's how to reproduce the issue (using python 3):

```
$ oleid e39d70df22c45338475656067ad245993db6921bb29aa7156969f4e53fccb222
oleid 0.51 - http://decalage.info/oletools
THIS IS WORK IN PROGRESS - Check updates regularly!
Please report any issue at https://github.com/decalage2/oletools/issues

Filename: e39d70df22c45338475656067ad245993db6921bb29aa7156969f4e53fccb222
Traceback (most recent call last):
  File "/usr/local/bin/oleid", line 11, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.6/site-packages/oletools/oleid.py", line 306, in main
    indicators = oleid.check()
  File "/usr/local/lib/python3.6/site-packages/oletools/oleid.py", line 188, in check
    self.check_flash()
  File "/usr/local/lib/python3.6/site-packages/oletools/oleid.py", line 277, in check_flash
    found = detect_flash(data)
  File "/usr/local/lib/python3.6/site-packages/oletools/oleid.py", line 120, in detect_flash
    ver = struct.unpack('<b', data[start+3])[0]
TypeError: a bytes-like object is required, not 'int'
```

The problem is that `data[start+3]` returns an int in python 3, which makes `struct.unpack` unhappy. The change just adds an ending index to make sure the retuned value is a byte. I tested this change doesn't break python 2.