### PR TITLE
Fix AttributeError: 'str' object has no attribute 'decode'.

### DIFF
--- a/oletools/olevba3.py
+++ b/oletools/olevba3.py
@@ -2878,7 +2878,9 @@ class VBA_Parser(object):
                 self.vba_code_all_modules = ''
                 for (_, _, _, vba_code) in self.extract_all_macros():
                     #TODO: filter code? (each module)
-                    self.vba_code_all_modules += vba_code.decode('utf-8', 'ignore') + '\n'
+                    if isinstance(vba_code, bytes):
+                        vba_code = vba_code.decode('utf-8', 'ignore')
+                    self.vba_code_all_modules += vba_code + '\n'
                 for (_, _, form_string) in self.extract_form_strings():
                     self.vba_code_all_modules += form_string.decode('utf-8', 'ignore') + '\n'
             # Analyze the whole code at once:


### PR DESCRIPTION
extract_macros() returns vba_code as bytes or string (string only for
OpenXML/PPT -- open_text() decodes bytes to string).

This way it is already implemented in process_file() and process_file_json().

Sample hash: 586DB43601FB55E89E67DFE569E1E9983779722ED47A8E1F23ADF54D04D3DF4B