### PR TITLE
Fix control words checks to be able to deal with malicious rtf files

### DIFF
--- a/oletools/olevba.py
+++ b/oletools/olevba.py
@@ -555,11 +555,9 @@ AUTOEXEC_KEYWORDS = {
     # any MS Office application:
     'Runs when the file is opened (using InkPicture ActiveX object)':
         # ref:https://twitter.com/joe4security/status/770691099988025345
-        (r'\w+_Painted|Painting',),
+        (r'\w+_Painted',),
     'Runs when the file is opened and ActiveX objects trigger events':
         (r'\w+_(?:GotFocus|LostFocus|MouseHover)',),
-    'Runs when the file is opened and a layout is initialised':
-        (r'(?:\w+_Layout',),
 }
 
 # Suspicious Keywords that may be used by malware

--- a/oletools/rtfobj.py
+++ b/oletools/rtfobj.py
@@ -273,24 +273,24 @@ DESTINATION_CONTROL_WORDS = frozenset((
     b"headerl", b"headerr", b"hl", b"hlfr", b"hlinkbase", b"hlloc", b"hlsrc", b"hsv", b"htmltag", b"info", b"keycode", b"keywords",
     b"latentstyles", b"lchars", b"levelnumbers", b"leveltext", b"lfolevel", b"linkval", b"list", b"listlevel", b"listname",
     b"listoverride", b"listoverridetable", b"listpicture", b"liststylename", b"listtable", b"listtext", b"lsdlockedexcept",
-    b"macc", b"maccPr", b"mailmerge", b"maln",b"malnScr", b"manager", b"margPr", b"mbar", b"mbarPr", b"mbaseJc", b"mbegChr",
-    b"mborderBox", b"mborderBoxPr", b"mbox", b"mboxPr", b"mchr", b"mcount", b"mctrlPr", b"md", b"mdeg", b"mdegHide", b"mden",
-    b"mdiff", b"mdPr", b"me", b"mendChr", b"meqArr", b"meqArrPr", b"mf", b"mfName", b"mfPr", b"mfunc", b"mfuncPr",b"mgroupChr",
-    b"mgroupChrPr",b"mgrow", b"mhideBot", b"mhideLeft", b"mhideRight", b"mhideTop", b"mhtmltag", b"mlim", b"mlimloc", b"mlimlow",
-    b"mlimlowPr", b"mlimupp", b"mlimuppPr", b"mm", b"mmaddfieldname", b"mmath", b"mmathPict", b"mmathPr",b"mmaxdist", b"mmc",
-    b"mmcJc", b"mmconnectstr", b"mmconnectstrdata", b"mmcPr", b"mmcs", b"mmdatasource", b"mmheadersource", b"mmmailsubject",
+    b"macc", b"maccpr", b"mailmerge", b"maln",b"malnscr", b"manager", b"margpr", b"mbar", b"mbarpr", b"mbasejc", b"mbegchr",
+    b"mborderbox", b"mborderboxpr", b"mbox", b"mboxpr", b"mchr", b"mcount", b"mctrlpr", b"md", b"mdeg", b"mdeghide", b"mden",
+    b"mdiff", b"mdpr", b"me", b"mendchr", b"meqarr", b"meqarrpr", b"mf", b"mfname", b"mfpr", b"mfunc", b"mfuncpr",b"mgroupchr",
+    b"mgroupchrpr",b"mgrow", b"mhidebot", b"mhideleft", b"mhideright", b"mhidetop", b"mhtmltag", b"mlim", b"mlimloc", b"mlimlow",
+    b"mlimlowpr", b"mlimupp", b"mlimupppr", b"mm", b"mmaddfieldname", b"mmath", b"mmathpict", b"mmathpr",b"mmaxdist", b"mmc",
+    b"mmcjc", b"mmconnectstr", b"mmconnectstrdata", b"mmcpr", b"mmcs", b"mmdatasource", b"mmheadersource", b"mmmailsubject",
     b"mmodso", b"mmodsofilter", b"mmodsofldmpdata", b"mmodsomappedname", b"mmodsoname", b"mmodsorecipdata", b"mmodsosort",
-    b"mmodsosrc", b"mmodsotable", b"mmodsoudl", b"mmodsoudldata", b"mmodsouniquetag", b"mmPr", b"mmquery", b"mmr", b"mnary",
-    b"mnaryPr", b"mnoBreak", b"mnum", b"mobjDist", b"moMath", b"moMathPara", b"moMathParaPr", b"mopEmu", b"mphant", b"mphantPr",
-    b"mplcHide", b"mpos", b"mr", b"mrad", b"mradPr", b"mrPr", b"msepChr", b"mshow", b"mshp", b"msPre", b"msPrePr", b"msSub",
-    b"msSubPr", b"msSubSup", b"msSubSupPr",  b"msSup", b"msSupPr", b"mstrikeBLTR", b"mstrikeH", b"mstrikeTLBR", b"mstrikeV",
-    b"msub", b"msubHide", b"msup", b"msupHide", b"mtransp", b"mtype", b"mvertJc", b"mvfmf", b"mvfml", b"mvtof", b"mvtol",
-    b"mzeroAsc", b"mzeroDesc", b"mzeroWid", b"nesttableprops", b"nexctfile", b"nonesttables", b"objalias", b"objclass",
+    b"mmodsosrc", b"mmodsotable", b"mmodsoudl", b"mmodsoudldata", b"mmodsouniquetag", b"mmpr", b"mmquery", b"mmr", b"mnary",
+    b"mnarypr", b"mnobreak", b"mnum", b"mobjdist", b"momath", b"momathpara", b"momathparapr", b"mopemu", b"mphant", b"mphantpr",
+    b"mplchide", b"mpos", b"mr", b"mrad", b"mradpr", b"mrpr", b"msepchr", b"mshow", b"mshp", b"mspre", b"msprepr", b"mssub",
+    b"mssubpr", b"mssubsup", b"mssubsuppr",  b"mssup", b"mssuppr", b"mstrikebltr", b"mstrikeh", b"mstriketlbr", b"mstrikev",
+    b"msub", b"msubhide", b"msup", b"msuphide", b"mtransp", b"mtype", b"mvertjc", b"mvfmf", b"mvfml", b"mvtof", b"mvtol",
+    b"mzeroasc", b"mzerodesc", b"mzerowid", b"nesttableprops", b"nexctfile", b"nonesttables", b"objalias", b"objclass",
     b"objdata", b"object", b"objname", b"objsect", b"objtime", b"oldcprops", b"oldpprops", b"oldsprops", b"oldtprops",
     b"oleclsid", b"operator", b"panose", b"password", b"passwordhash", b"pgp", b"pgptbl", b"picprop", b"pict", b"pn", b"pnseclvl",
     b"pntext", b"pntxta", b"pntxtb", b"printim",
-    # It seems \private should not be treated as a destination (issue #178)
-    # Same for \pxe (issue #196)
+    # it seems \private should not be treated as a destination (issue #178)
+    # same for \pxe (issue #196)
     # b"private", b"pxe",
     b"propname", b"protend", b"protstart", b"protusertbl",
     b"result", b"revtbl", b"revtim", b"rsidtbl", b"rtf", b"rxe", b"shp", b"shpgrp", b"shpinst", b"shppict", b"shprslt", b"shptxt",
@@ -298,7 +298,7 @@ DESTINATION_CONTROL_WORDS = frozenset((
     b"upr", b"userprops", b"wgrffmtfilter", b"windowcaption", b"writereservation", b"writereservhash", b"xe", b"xform",
     b"xmlattrname", b"xmlattrvalue", b"xmlclose", b"xmlname", b"xmlnstbl", b"xmlopen",
     # added for issue #292: https://github.com/decalage2/oletools/issues/292
-    b"margSz",
+    b"margsz",
     ))
 
 
@@ -531,7 +531,7 @@ class RtfParser(object):
         #log.debug('control word %r at index %Xh' % (matchobject.group(), self.index))
         # TODO: according to RTF specs v1.9.1, "Destination changes are legal only immediately after an opening brace ({)"
         # (not counting the special control symbol \*, of course)
-        if cword in DESTINATION_CONTROL_WORDS:
+        if cword.lower() in DESTINATION_CONTROL_WORDS:
             # log.debug('%r is a destination control word: starting a new destination' % cword)
             self._open_destination(matchobject, cword)
         # call the corresponding user method for additional processing:


### PR DESCRIPTION
 A recent campaign of malicious rtf's started changing the case of some control words. The control word in this case is "\mlimLow". In rtfobj the DESTINATION_CONTROL_WORDS set contains the control word but it is all lower case "\mlimlow"while in the rtf it is "\mlimLow". Because the control word is not matched in the function _control_word the size of the OLE object extracted is incorrect and thus a malformed object is produced.

The suggested fix changes the DESTINATION_CONTROL_WORDS set to be all lowercase and the comparison is then done between the lowercase of the extracted control word and the one in the set.

Below is a list of rtfs that cause this bug in rtfobj.py

03312bced4cc282ab3972690f7bd91b5030d1c80f4fd698d06e516701af1f53c
07b59e17b0a5a729ea7e5895a795f31b61ef87c9f686120ed8b92e232aae9bdb
0c570b7623e860a08dae7939f777eeb425ca3fbb552abf403382652e8faf177f
182b7db8d0ce4c67ff8e36b6243c57dc9526dd818df8d789fdc7dbf01c6da364
19781d0395b153010d5dbce493ac669a58a9ea139a53b7bb29982599b1d156be
2418961e9de668a5976e8fa0a74ee4c062240924178af19a4210e2cd21e55c15
25ee59ef8caed585ed76c0330c0fff672855f666b7d1c975ddf4d44a434c0f5e
3c451d9962d5ffad109bf80178169ea80134cbafbf445fd7b005e8ac5ee095ee
43b737f262f4cff9fc863470f3c371ef08efffb19a4221ef5488fc78663cf104
5da37139e0800d610f8ed9561d2dd86779e6985074640f2606895e27503e56aa
66cbc96da4a5436974a40b823470d330a3daf47f0e6a1912ed40b40780873dca
68f11f7caab92dec81665f612ba493e536ebc9d9c1c0fcd9c188cbae486ef0d5
80d16ec4250bfc1afd4272198d51b7299fae7c622d0123df363ac7735bd3ee14
8a1c5025d8c631ca1e8cb36840b9063ca636948627b2c37e931dcf47f97222c5
8cd49f312b8dfc02aeda3b71913775f2ee3cdd03c9e5c515b2886216df83567a
950b0e7d1b70b2fc424388f15cfff0ed698f116db7463d44bd02f6cf6652c98b
b50edd5e1161b2c336658fcd7eadaf50594d5822437c7b61622dc3eef7ddcdae
bc3db10b53beaf34f2b938e2921953af1fb4fbbaac74dd017a859b1cc775f26b
bc5a244ef3a51ab804cd8aee5c719eb4da1cf8d39f206138101169550ded787c
d615405e2b8e238c4ce09d325f71132ba8a5ff049020c9e9711af1d4dc4231e7
de71a325ea172e94f0e3eb1cc4e30dc94d240506e45f8f24947e7eb68b5a2ef7
df1c21e26517862d91262874a9e20c439c266bd5f2336915f855fd123805b7f2
e54ab77fb9db619db6c6867466a21245d298ba67f63ba49b131e774f14033774
ed9e07f525eb84963acb2bbfa0c4c5bf3909d6f99b103ac53af189ca996f4a46
f3ec8c378a2cf24f646bb7f4ec7a6752201674bab46f2ec4f9c457b401f65b8c
f483a9c7dbb8942160e7e9dd7607e1cd3f74eb22fabedeec273d98077e3b8a88
f7cb1860a5daed331d40f492c4ee730eef7f5abb8a2126bb544a3e058eeb15ff