### PR TITLE
Fix ignoring of optional whitespace after \bin.

### DIFF
--- a/oletools/rtfobj.py
+++ b/oletools/rtfobj.py
@@ -578,7 +578,7 @@ class RtfParser(object):
             # it should be treated as a null length:
             binlen=0
         # ignore optional space after \bin
-        if self.data[self.index] == ' ':
+        if self.data[self.index] == ord(' '):
             log.debug('\\bin: ignoring whitespace before data')
             self.index += 1
         log.debug('\\bin: reading %d bytes of binary data' % binlen)

--- a/oletools/rtfobj.py
+++ b/oletools/rtfobj.py
@@ -578,7 +578,7 @@ class RtfParser(object):
             # it should be treated as a null length:
             binlen=0
         # ignore optional space after \bin
-        if self.data[self.index] == ord(' '):
+        if ord(self.data[self.index:self.index + 1]) == ord(' '):
             log.debug('\\bin: ignoring whitespace before data')
             self.index += 1
         log.debug('\\bin: reading %d bytes of binary data' % binlen)


### PR DESCRIPTION
The condition is always False because `self.data[self.index]` returns integer.

Try to put this in code before the condition:
```
>>> print(type(self.data[self.index]))  # <class 'int'>
>>> print(self.data[self.index])        # 32
```

Thus even with space at self.index it fails:
`>>> 32 == ' '  # False`