### PR TITLE
Stop tests from failing when using python3.7 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,21 @@
 language: python
-
-python:
-  - "2.7"
-  - "3.6"
-  - "nightly"
 cache: pip
+sudo: false
+
+matrix:
+  include:
+    - python: 2.7
+    - python: 3.4
+    - python: 3.5
+    - python: 3.6
+    - python: 3.7
+      dist: xenial
+      sudo: yes
+    - python: nightly
+      dist: xenial
+      sudo: yes
+    - python: pypy
+    - python: pypy3
+
 script:
   - python setup.py test

--- a/oletools/ooxml.py
+++ b/oletools/ooxml.py
@@ -598,11 +598,11 @@ class XmlParser(object):
             logging.warning('Did not iterate through complete file. '
                             'Should run iter_xml() without args, first.')
         if not self.subfiles_no_xml:
-            raise StopIteration()
+            return
 
         # case of single xml files (office 2003+)
         if self.is_single_xml():
-            raise StopIteration()   # "return"
+            return
 
         content_types, content_defaults = self.get_content_types()
 

--- a/tests/msodde/test_csv.py
+++ b/tests/msodde/test_csv.py
@@ -49,7 +49,7 @@ class TestCSV(unittest.TestCase):
 
                             sample = \
                                 prefix.format(quote=quote, delim=delim) + \
-                                quote + sample_core + quote + \
+                                quote + sample_core + quote + delim + \
                                 suffix.format(quote=quote, delim=delim)
                             output = self.write_and_run(sample)
                             n_links = len(self.get_dde_from_output(output))


### PR DESCRIPTION
* Updated .travis.yml to use more recent versions of python 3.7 and 3.8(nightly) (Travis' `python: nightly` was an outdated 3.7)
* Removed usage of `raise StopIteration` which is deprecated from 3.7 on (PEP-479)
* `csv.Sniffer` was changed [lately](https://bugs.python.org/issue30157) and behaves now different in some cases (this also affects python 2.7 and 3.6). This PR changes the generated test CSV to also contain a delimiter at the end of the line of `sample_core`. 

I'm not 100% sure if this is the correct way to fix this now failing test. Since now when using a new version of python and if there is no delimiter in this line `csv.Sniffer` might detect the quoting-character of this line as delimiter character and therefore not extract the correct cells/values.