### PR TITLE
Fix comparsion against string

### DIFF
--- a/oletools/rtfobj.py
+++ b/oletools/rtfobj.py
@@ -718,7 +718,7 @@ class RtfObjParser(RtfParser):
     def control_symbol(self, matchobject):
         # log.debug('control symbol %r at index %Xh' % (matchobject.group(), self.index))
         symbol = matchobject.group()[1:2]
-        if symbol == "'":
+        if symbol == b"'":
             # read the two hex digits following "\'" - which can be any characters, not just hex digits
             # (because within an objdata destination, they are simply ignored)
             hexdigits = self.data[self.index+2:self.index+4]


### PR DESCRIPTION
A missing "b" was the reason for the different output in python2 and python3 in #347.
With this PR rtfobj detects the OLE object in python3, too.

    rtfobj 0.53.1 on Python 3.6.5 - http://decalage.info/python/oletools
    THIS IS WORK IN PROGRESS - Check updates regularly!
    Please report any issue at https://github.com/decalage2/oletools/issues
    
    ===============================================================================
    File: '5771308(1).doc' - size: 92648 bytes
    ---+----------+---------------------------------------------------------------
    id |index     |OLE Object
    ---+----------+---------------------------------------------------------------
    0  |00009BFFh |format_id: 2 (Embedded)
       |          |class name: b'B56SHdydZaYzS8GGe'
       |          |data size: 3584
       |          |CLSID: FF0F5000-FFFF-FFFF-FFFF-F0100000002C
       |          |unknown CLSID (please report at
       |          |https://github.com/decalage2/oletools/issues)
    ---+----------+---------------------------------------------------------------

