### PR TITLE
setup: create MANIFEST so source-tarball includes tests

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+recursive-include tests *.py
+graft tests/test-data


### PR DESCRIPTION
When creating source tarball	via "python setup.py sdist" or
"python setup.py bdist_rpm", then include test code and data so can
still run unittests. This does not affect the rpms.

Tried first to achieve this effect (test[-data] included in source but not
in rpm) using options in setup.py but failed.