### PR TITLE
Update rtfobj to use the extension from the temp path of an embedded Package object

### DIFF
--- a/oletools/rtfobj.py
+++ b/oletools/rtfobj.py
@@ -880,9 +880,16 @@ def process_file(container, filename, data, output_dir=None, save_object=False):
                 ole_column += '\nTemp path = %r' % rtfobj.temp_path
                 ole_color = 'yellow'
                 # check if the file extension is executable:
-                _, ext = os.path.splitext(rtfobj.temp_path)
-                log.debug('File extension: %r' % ext)
-                if re_executable_extensions.match(ext):
+
+                _, temp_ext = os.path.splitext(rtfobj.temp_path)
+                log.debug('Temp path extension: %r' % temp_ext)
+                _, file_ext = os.path.splitext(rtfobj.filename)
+                log.debug('File extension: %r' % file_ext)
+
+                if temp_ext != file_ext:
+                    ole_column += "\nMODIFIED FILE EXTENSION"
+
+                if re_executable_extensions.match(temp_ext) or re_executable_extensions.match(file_ext):
                     ole_color = 'red'
                     ole_column += '\nEXECUTABLE FILE'
             # else:

--- a/oletools/rtfobj.py
+++ b/oletools/rtfobj.py
@@ -880,7 +880,7 @@ def process_file(container, filename, data, output_dir=None, save_object=False):
                 ole_column += '\nTemp path = %r' % rtfobj.temp_path
                 ole_color = 'yellow'
                 # check if the file extension is executable:
-                _, ext = os.path.splitext(rtfobj.filename)
+                _, ext = os.path.splitext(rtfobj.temp_path)
                 log.debug('File extension: %r' % ext)
                 if re_executable_extensions.match(ext):
                     ole_color = 'red'


### PR DESCRIPTION
Small change which uses the extension of an embedded object from the temp_path instead of the filename. 

In cases where the embedded object is an executable file, rtfobj will display a warning for the analyst in red. If the filename extension is altered or removed, the output formatting defaults to yellow.  The extension within the temp path can't be modified otherwise it won't be executed using the correct handler for the filetype. 

In most cases I don't think it matters as an analyst reviewing the output will review all of the artifacts, but it could be used as a method to obfuscate an embedded executable object. Example: Including many embedded objects and other artifacts that fill an analysts screen.

