### PR TITLE
Type-Field in logging

### DIFF
--- a/oletools/common/log_helper/_json_formatter.py
+++ b/oletools/common/log_helper/_json_formatter.py
@@ -13,8 +13,13 @@ class JsonFormatter(logging.Formatter):
         Since we don't buffer messages, we always prepend messages with a comma to make
         the output JSON-compatible. The only exception is when printing the first line,
         so we need to keep track of it.
+
+        We assume that all input comes from the OletoolsLoggerAdapter which
+        ensures that there is a `type` field in the record. Otherwise will have
+        to add a try-except around the access to `record.type`.
         """
         json_dict = dict(msg=record.msg, level=record.levelname)
+        json_dict['type'] = record.type
         formatted_message = '    ' + json.dumps(json_dict)
 
         if self._is_first_line:

--- a/oletools/common/log_helper/_logger_adapter.py
+++ b/oletools/common/log_helper/_logger_adapter.py
@@ -8,17 +8,44 @@ class OletoolsLoggerAdapter(logging.LoggerAdapter):
     """
     _json_enabled = None
 
-    def print_str(self, message):
+    def print_str(self, message, **kwargs):
         """
         This function replaces normal print() calls so we can format them as JSON
         when needed or just print them right away otherwise.
         """
         if self._json_enabled and self._json_enabled():
             # Messages from this function should always be printed,
-            # so when using JSON we log using the same level that set
-            self.log(_root_logger_wrapper.level(), message)
+            # so when using JSON we log using the same level that set.
+            # Additional information in kwargs is added to LogRecord
+            self.log(_root_logger_wrapper.level(), message, extra=kwargs)
         else:
             print(message)
+
+    def log(self, lvl, msg, *args, **kwargs):
+        """
+        Run :py:meth:`process` on kwargs, then forward to actual logger.
+
+        This is based on the logging cookbox, section "Using LoggerAdapter to
+        impart contextual information".
+        """
+        msg, kwargs = self.process(msg, kwargs)
+        self.logger.log(lvl, msg, *args, **kwargs)
+
+    def process(self, msg, kwargs):
+        """
+        Ensure `kwargs['extra']['type']` exists, init with given arg `type`.
+
+        The `type` field will be added to the :py:class:`logging.LogRecord` and
+        is used by the :py:class:`JsonFormatter`.
+        """
+        if 'extra' not in kwargs:
+            kwargs['extra'] = {}
+        if 'type' in kwargs:
+            kwargs['extra']['type'] = kwargs['type']
+            del kwargs['type']    # downstream loggers cannot deal with this
+        if 'type' not in kwargs['extra']:
+            kwargs['extra']['type'] = 'msg'   # type will be added to LogRecord
+        return msg, kwargs
 
     def set_json_enabled_function(self, json_enabled):
         """

--- a/oletools/msodde.py
+++ b/oletools/msodde.py
@@ -1018,7 +1018,8 @@ def main(cmd_line_args=None):
         logger.exception(str(exc))
 
     logger.print_str('DDE Links:')
-    logger.print_str(text)
+    for link in text.splitlines():
+        logger.print_str(text, type='dde-link')
 
     log_helper.end_logging()
 

--- a/tests/common/log_helper/log_helper_test_imported.py
+++ b/tests/common/log_helper/log_helper_test_imported.py
@@ -11,6 +11,8 @@ INFO_MESSAGE = 'imported: info log'
 WARNING_MESSAGE = 'imported: warning log'
 ERROR_MESSAGE = 'imported: error log'
 CRITICAL_MESSAGE = 'imported: critical log'
+RESULT_MESSAGE = 'imported: result log'
+RESULT_TYPE = 'imported: result'
 
 logger = log_helper.get_or_create_silent_logger('test_imported', logging.ERROR)
 
@@ -21,3 +23,4 @@ def log():
     logger.warning(WARNING_MESSAGE)
     logger.error(ERROR_MESSAGE)
     logger.critical(CRITICAL_MESSAGE)
+    logger.info(RESULT_MESSAGE, type=RESULT_TYPE)

--- a/tests/common/log_helper/log_helper_test_main.py
+++ b/tests/common/log_helper/log_helper_test_main.py
@@ -9,6 +9,8 @@ INFO_MESSAGE = 'main: info log'
 WARNING_MESSAGE = 'main: warning log'
 ERROR_MESSAGE = 'main: error log'
 CRITICAL_MESSAGE = 'main: critical log'
+RESULT_MESSAGE = 'main: result log'
+RESULT_TYPE = 'main: result'
 
 logger = log_helper.get_or_create_silent_logger('test_main')
 
@@ -50,6 +52,7 @@ def _log():
     logger.warning(WARNING_MESSAGE)
     logger.error(ERROR_MESSAGE)
     logger.critical(CRITICAL_MESSAGE)
+    logger.info(RESULT_MESSAGE, type=RESULT_TYPE)
     log_helper_test_imported.log()
 
 

--- a/tests/common/log_helper/test_log_helper.py
+++ b/tests/common/log_helper/test_log_helper.py
@@ -61,6 +61,57 @@ class TestLogHelper(unittest.TestCase):
             log_helper_test_imported.CRITICAL_MESSAGE
         ])
 
+    def test_logs_type_ignored(self):
+        """Run test script with logging enabled at info level. Want no type."""
+        output = self._run_test(['enable', 'info'])
+
+        expect = '\n'.join([
+            'INFO     ' + log_helper_test_main.INFO_MESSAGE,
+            'WARNING  ' + log_helper_test_main.WARNING_MESSAGE,
+            'ERROR    ' + log_helper_test_main.ERROR_MESSAGE,
+            'CRITICAL ' + log_helper_test_main.CRITICAL_MESSAGE,
+            'INFO     ' + log_helper_test_main.RESULT_MESSAGE,
+            'INFO     ' + log_helper_test_imported.INFO_MESSAGE,
+            'WARNING  ' + log_helper_test_imported.WARNING_MESSAGE,
+            'ERROR    ' + log_helper_test_imported.ERROR_MESSAGE,
+            'CRITICAL ' + log_helper_test_imported.CRITICAL_MESSAGE,
+            'INFO     ' + log_helper_test_imported.RESULT_MESSAGE,
+        ])
+        self.assertEqual(output, expect)
+
+    def test_logs_type_in_json(self):
+        """Check type field is contained in json log."""
+        output = self._run_test(['enable', 'as-json', 'info'])
+
+        # convert to json preserving order of output
+        jout = json.loads(output)
+
+        jexpect = [
+            dict(type='msg', level='INFO',
+                 msg=log_helper_test_main.INFO_MESSAGE),
+            dict(type='msg', level='WARNING',
+                 msg=log_helper_test_main.WARNING_MESSAGE),
+            dict(type='msg', level='ERROR',
+                 msg=log_helper_test_main.ERROR_MESSAGE),
+            dict(type='msg', level='CRITICAL',
+                 msg=log_helper_test_main.CRITICAL_MESSAGE),
+            # this is the important entry (has a different "type" field):
+            dict(type=log_helper_test_main.RESULT_TYPE, level='INFO',
+                 msg=log_helper_test_main.RESULT_MESSAGE),
+            dict(type='msg', level='INFO',
+                 msg=log_helper_test_imported.INFO_MESSAGE),
+            dict(type='msg', level='WARNING',
+                 msg=log_helper_test_imported.WARNING_MESSAGE),
+            dict(type='msg', level='ERROR',
+                 msg=log_helper_test_imported.ERROR_MESSAGE),
+            dict(type='msg', level='CRITICAL',
+                 msg=log_helper_test_imported.CRITICAL_MESSAGE),
+            # ... and this:
+            dict(type=log_helper_test_imported.RESULT_TYPE, level='INFO',
+                 msg=log_helper_test_imported.RESULT_MESSAGE),
+        ]
+        self.assertEqual(jout, jexpect)
+
     def test_json_correct_on_exceptions(self):
         """
         Test that even on unhandled exceptions our JSON is always correct

--- a/tests/common/log_helper/test_log_helper.py
+++ b/tests/common/log_helper/test_log_helper.py
@@ -125,10 +125,10 @@ class TestLogHelper(unittest.TestCase):
     def _assert_json_messages(self, output, messages):
         try:
             json_data = json.loads(output)
-            self.assertEquals(len(json_data), len(messages))
+            self.assertEqual(len(json_data), len(messages))
 
             for i in range(len(messages)):
-                self.assertEquals(messages[i], json_data[i]['msg'])
+                self.assertEqual(messages[i], json_data[i]['msg'])
         except ValueError:
             self.fail('Invalid json:\n' + output)
 
@@ -155,7 +155,7 @@ class TestLogHelper(unittest.TestCase):
         if not isinstance(output, str):
             output = output.decode('utf-8')
 
-        self.assertEquals(child.returncode == 0, should_succeed)
+        self.assertEqual(child.returncode == 0, should_succeed)
 
         return output.strip()
 


### PR DESCRIPTION
Add an optional "type" field to logging calls that is ignored in "regular" logging to console but shows in json output. 

This is a way to bring some kind of structure into json output which since merging of PR #308 (Unified logging with json) is just a list of log-messages wrapped into json. There is no structure any more which of those messages is status, which is result, etc, and that makes parsing json equally complicated as parsing the regular non-json output.

This PR represents a low-impact start of a solution. The "type" field can mark a message as "result", as an example used this in msodde.

This might not be the final word on this topic since the discussion on how to get stable json output is not finished. But it allows to create json output that is much easier to parse until a better solution emerges.