### PR TITLE
Fix TypeError in VBA_Parser.analyze_macros() (can't concat bytes to s…

### DIFF
--- a/oletools/olevba.py
+++ b/oletools/olevba.py
@@ -3273,7 +3273,8 @@ class VBA_Parser(object):
                         compressed_code = data[start:]
                         try:
                             vba_code = decompress_stream(bytearray(compressed_code))
-                            # TODO vba_code = self.encode_string(vba_code)
+                            encoding = chardet.detect(vba_code)['encoding'] or 'utf-8'
+                            vba_code = bytes2str(vba_code, encoding)
                             yield (self.filename, d.name, d.name, vba_code)
                         except Exception as exc:
                             # display the exception with full stack trace for debugging


### PR DESCRIPTION
…tr).

Similar to PR #288.

`decompress_stream()` yields bytes but `vba_code` value returned from
`extract_macros()` should be AFAIK string (at least all other `yield`s return
string.

Sample that failed: 871beebb71290d040584fa7587c608b50e0d42e0f7657e10946de640ee4c3f1b