### PR TITLE
Msodde failed decrypt fix

### DIFF
--- a/oletools/common/log_helper/_json_formatter.py
+++ b/oletools/common/log_helper/_json_formatter.py
@@ -18,7 +18,7 @@ class JsonFormatter(logging.Formatter):
         ensures that there is a `type` field in the record. Otherwise will have
         to add a try-except around the access to `record.type`.
         """
-        json_dict = dict(msg=record.msg, level=record.levelname)
+        json_dict = dict(msg=record.msg.replace('\n', ' '), level=record.levelname)
         json_dict['type'] = record.type
         formatted_message = '    ' + json.dumps(json_dict)
 

--- a/oletools/crypto.py
+++ b/oletools/crypto.py
@@ -34,6 +34,8 @@ potentially encrypted files::
         decrypted_file = None
         try:
             decrypted_file = crypto.decrypt(input_file, passwords)
+            if decrypted_file is None:
+                raise crypto.WrongEncryptionPassword(input_file)
             # might still be encrypted, so call this again recursively
             result = script_main_function(decrypted_file, passwords,
                                           crypto_nesting+1, args)
@@ -341,7 +343,7 @@ def decrypt(filename, passwords=None, **temp_file_args):
                            `dirname` or `prefix`. `suffix` will default to
                            suffix of input `filename`, `prefix` defaults to
                            `oletools-decrypt-`; `text` will be ignored
-    :returns: name of the decrypted temporary file.
+    :returns: name of the decrypted temporary file (type str) or `None`
     :raises: :py:class:`ImportError` if :py:mod:`msoffcrypto-tools` not found
     :raises: :py:class:`ValueError` if the given file is not encrypted
     """

--- a/oletools/olevba.py
+++ b/oletools/olevba.py
@@ -4062,8 +4062,13 @@ def process_file(filename, data, container, options, crypto_nesting=0):
     except Exception:
         raise
     finally:     # clean up
-        if decrypted_file is not None and os.path.isfile(decrypted_file):
+        try:
+            log.debug('Removing crypt temp file {}'.format(decrypted_file))
             os.unlink(decrypted_file)
+        except Exception:   # e.g. file does not exist or is None
+            pass
+    # no idea what to return now
+    raise Exception('Programming error -- should never have reached this!')
 
 
 def main(cmd_line_args=None):

--- a/tests/msodde/test_basic.py
+++ b/tests/msodde/test_basic.py
@@ -120,15 +120,11 @@ class TestErrorOutput(unittest.TestCase):
         for suffix in 'doc', 'docm', 'docx', 'ppt', 'pptm', 'pptx', 'xls', \
                 'xlsb', 'xlsm', 'xlsx':
             example_file = join(BASE_DIR, 'encrypted', 'encrypted.' + suffix)
-            output, ret_code = call_and_capture('msodde', ['-j', example_file],
+            output, ret_code = call_and_capture('msodde', [example_file, ],
                                                 accept_nonzero_exit=True)
             self.assertEqual(ret_code, 1)
-            data = json.loads(output, object_pairs_hook=OrderedDict)
-            # debug: json.dump(data, sys.stdout, indent=4)
-            self.assertTrue(all(part['type'] == 'msg' for part in data))
-            self.assertTrue(any(part['level'] == 'ERROR' and
-                                'passwords could not decrypt' in part['msg']
-                                for part in data))
+            self.assertIn('passwords could not decrypt office file', output,
+                          msg='Unexpected output: {}'.format(output.strip()))
 
 
 class TestDdeLinks(unittest.TestCase):


### PR DESCRIPTION
This fixes a stupid little bug introduced when integrating crypto into msodde: check whether decryption actually worked and raise appropriate error if not.

Fixed this also in crypto recommendations and created a unittest