### PR TITLE
ppt_parser: fix type of decompressed data

### DIFF
--- a/oletools/ppt_parser.py
+++ b/oletools/ppt_parser.py
@@ -1615,7 +1615,7 @@ def iterative_decompress(stream, size, chunk_size=4096):
 
     decompressor = zlib.decompressobj()
     n_read = 0
-    decomp = ''
+    decomp = b''
     return_err = None
 
     try:


### PR DESCRIPTION
Another py2/py3-error: returned data is str in py2, bytes in py3

Probably fixes issue #177 