### PR TITLE
Pcode options + fixes

### DIFF
--- a/oletools/olevba.py
+++ b/oletools/olevba.py
@@ -3835,6 +3835,7 @@ class VBA_Parser_CLI(VBA_Parser):
         :param global_analysis: bool, if True all modules are merged for a single analysis (default),
                                 otherwise each module is analyzed separately (old behaviour)
         :param hide_attributes: bool, if True the first lines starting with "Attribute VB" are hidden (default)
+        :param show_deobfuscated_code: bool, if True add deobfuscated code to result
         :param deobfuscate: bool, if True attempt to deobfuscate VBA expressions (slow)
         """
         #TODO: fix conflicting parameters (?)

--- a/oletools/olevba.py
+++ b/oletools/olevba.py
@@ -3822,7 +3822,7 @@ class VBA_Parser_CLI(VBA_Parser):
     def process_file_json(self, show_decoded_strings=False,
                           display_code=True, hide_attributes=True,
                           vba_code_only=False, show_deobfuscated_code=False,
-                          deobfuscate=False):
+                          deobfuscate=False, show_pcode=False):
         """
         Process a single file
 
@@ -3837,6 +3837,7 @@ class VBA_Parser_CLI(VBA_Parser):
         :param hide_attributes: bool, if True the first lines starting with "Attribute VB" are hidden (default)
         :param show_deobfuscated_code: bool, if True add deobfuscated code to result
         :param deobfuscate: bool, if True attempt to deobfuscate VBA expressions (slow)
+        :param show_pcode: bool, if True add extracted pcode to result
         """
         #TODO: fix conflicting parameters (?)
 
@@ -3854,6 +3855,7 @@ class VBA_Parser_CLI(VBA_Parser):
         result['analysis'] = None
         result['code_deobfuscated'] = None
         result['do_deobfuscate'] = deobfuscate
+        result['show_pcode'] = show_pcode
 
         try:
             #TODO: handle olefile errors, when an OLE file is malformed
@@ -3882,6 +3884,8 @@ class VBA_Parser_CLI(VBA_Parser):
                                                                   deobfuscate)
                 if show_deobfuscated_code:
                     result['code_deobfuscated'] = self.reveal()
+                if show_pcode:
+                    result['pcode'] = self.extract_pcode()
             result['macros'] = macros
             result['json_conversion_successful'] = True
         except Exception as exc:
@@ -4063,7 +4067,7 @@ def process_file(filename, data, container, options, crypto_nesting=0):
                          display_code=options.display_code,
                          hide_attributes=options.hide_attributes, vba_code_only=options.vba_code_only,
                          show_deobfuscated_code=options.show_deobfuscated_code,
-                         deobfuscate=options.deobfuscate))
+                         deobfuscate=options.deobfuscate, pcode=pcode))
         else:  # (should be impossible)
             raise ValueError('unexpected output mode: "{0}"!'.format(options.output_mode))
 

--- a/oletools/olevba.py
+++ b/oletools/olevba.py
@@ -4180,8 +4180,6 @@ def main(cmd_line_args=None):
     if options.show_deobfuscated_code and not options.deobfuscate:
         log.debug('set --deobf because --reveal was set')
         options.deobfuscate = True
-    if options.output_mode == 'triage' and options.show_deobfuscated_code:
-        log.debug('ignoring option --reveal in triage output mode')
 
     # gather info on all files that must be processed
     # ignore directory names stored in zip files:
@@ -4198,6 +4196,12 @@ def main(cmd_line_args=None):
             options.output_mode = 'detailed'
         else:
             options.output_mode = 'triage'
+
+    if options.output_mode == 'triage':
+        if options.show_deobfuscated_code:
+            log.debug('ignoring option --reveal in triage output mode')
+        if options.show_pcode:
+            log.debug('ignoring option --show-pcode in triage output mode')
 
     # Column headers for triage mode
     if options.output_mode == 'triage':

--- a/oletools/olevba.py
+++ b/oletools/olevba.py
@@ -4040,6 +4040,9 @@ def parse_args(cmd_line_args=None):
         parser.print_help()
         sys.exit(RETURN_WRONG_ARGS)
 
+    if options.show_pcode and options.no_pcode:
+        parser.error('You cannot combine options --no-pcode and --show-pcode')
+
     options.loglevel = LOG_LEVELS[options.loglevel]
 
     return options

--- a/oletools/olevba.py
+++ b/oletools/olevba.py
@@ -4101,8 +4101,6 @@ def process_file(filename, data, container, options, crypto_nesting=0):
         log.info('Working on decrypted file')
         return process_file(decrypted_file, data, container or filename,
                             options, crypto_nesting+1)
-    except Exception:
-        raise
     finally:     # clean up
         try:
             log.debug('Removing crypt temp file {}'.format(decrypted_file))

--- a/oletools/olevba.py
+++ b/oletools/olevba.py
@@ -3713,7 +3713,7 @@ class VBA_Parser_CLI(VBA_Parser):
     def process_file(self, show_decoded_strings=False,
                      display_code=True, hide_attributes=True,
                      vba_code_only=False, show_deobfuscated_code=False,
-                     deobfuscate=False, pcode=False):
+                     deobfuscate=False, show_pcode=False):
         """
         Process a single file
 
@@ -3725,7 +3725,7 @@ class VBA_Parser_CLI(VBA_Parser):
                                 otherwise each module is analyzed separately (old behaviour)
         :param hide_attributes: bool, if True the first lines starting with "Attribute VB" are hidden (default)
         :param deobfuscate: bool, if True attempt to deobfuscate VBA expressions (slow)
-        :param pcode bool: if True, call pcodedmp to disassemble P-code and display it
+        :param show_pcode bool: if True, call pcodedmp to disassemble P-code and display it
         """
         #TODO: replace print by writing to a provided output file (sys.stdout by default)
         # fix conflicting parameters:
@@ -3795,7 +3795,7 @@ class VBA_Parser_CLI(VBA_Parser):
                     # display the exception with full stack trace for debugging
                     log.info('Error parsing form: %s' % exc)
                     log.debug('Traceback:', exc_info=True)
-                if pcode:
+                if show_pcode:
                     print('-' * 79)
                     print('P-CODE disassembly:')
                     pcode = self.extract_pcode()
@@ -4011,9 +4011,9 @@ def parse_args(cmd_line_args=None):
                         default=False,
                         help='Do not raise errors if opening of substream '
                              'fails')
-    parser.add_argument('--pcode', dest="pcode", action="store_true",
+    parser.add_argument('--show-pcode', dest="show_pcode", action="store_true",
                         default=False,
-                        help="Disassemble and display the P-code (using pcodedmp)")
+                        help="Show disassembled P-code (using pcodedmp)")
 
     options = parser.parse_args(cmd_line_args)
 
@@ -4051,7 +4051,7 @@ def process_file(filename, data, container, options, crypto_nesting=0):
                          display_code=options.display_code,
                          hide_attributes=options.hide_attributes, vba_code_only=options.vba_code_only,
                          show_deobfuscated_code=options.show_deobfuscated_code,
-                         deobfuscate=options.deobfuscate, pcode=options.pcode)
+                         deobfuscate=options.deobfuscate, show_pcode=options.show_pcode)
         elif options.output_mode == 'triage':
             # summarized output for triage:
             vba_parser.process_file_triage(show_decoded_strings=options.show_decoded_strings,

--- a/oletools/ppt_parser.py
+++ b/oletools/ppt_parser.py
@@ -1615,7 +1615,7 @@ def iterative_decompress(stream, size, chunk_size=4096):
 
     decompressor = zlib.decompressobj()
     n_read = 0
-    decomp = ''
+    decomp = b''
     return_err = None
 
     try:


### PR DESCRIPTION
This PR adds an option to disable pcode-extraction and renames the existing "pcode" option.

During coding I found a few minor errors that I fixed right away, these are the commits in the beginning. The ppt_parser-commit was cherry-picked from another PR (#450), I needed it for testing. Feel free to just pick&merge part of these.

Rationale behind the main change:
contrary to its help string, option "pcode" does not (any more) determine whether pcode is extracted and analyzed or not. That happens always. It only determines whether the pcode is shown to the user in the normal "detailed" output mode. I also implemented pcode-output in "json" output-mode and added a warning if pcode should be shown in triage mode. I renamed it "show_pcode".

To bring back the original meaning of the pcode-option, I added an option "disable-pcode". As an alternative to this solution (having "show_pcode" and "disable_pcode"), I could implement an option "pcode" that has choices "OFF" (do not extract), "ANALYZE" (extract and analyze) and "SHOW" (also add it to output). Let me know if you prefer that.