### PR TITLE
changed reading mode in ooxml

### DIFF
--- a/oletools/ooxml.py
+++ b/oletools/ooxml.py
@@ -428,7 +428,7 @@ class XmlParser(object):
         if self.is_single_xml():
             if args:
                 raise BadOOXML(self.filename, 'xml has no subfiles')
-            with open(self.filename, 'r') as handle:
+            with open(self.filename, 'rb') as handle:
                 yield None, handle   # the subfile=None is needed in iter_xml
             self.did_iter_all = True
         else:


### PR DESCRIPTION
changed reading mode in ooxml.XMLParser.iter_files() for single xml  to rb. With the 'r' mode, it's impossible to parse excel-xml 2003 and 2007