### PR TITLE
Use given encoding in bytes2str (olevba).

### DIFF
--- a/oletools/olevba.py
+++ b/oletools/olevba.py
@@ -397,7 +397,7 @@ def bytes2str(bytes_string, encoding='utf8'):
     if PYTHON2:
         return bytes_string
     else:
-        return bytes_string.decode('utf8', errors='replace')
+        return bytes_string.decode(encoding, errors='replace')
 
 
 # === LOGGING =================================================================


### PR DESCRIPTION
`encoding` parameter is passed to `bytes2str()` and it's also mentioned in its
description but method actually always used UTF-8.