### PR TITLE
Avoid stream copies

### DIFF
--- a/oletools/thirdparty/oledump/plugin_biff.py
+++ b/oletools/thirdparty/oledump/plugin_biff.py
@@ -1028,10 +1028,10 @@ class cBIFF(object):  # cPluginParent):
             if options.find.startswith('0x'):
                 options.find = binascii.a2b_hex(options.find[2:])
 
+            formatcodes = 'HH'
+            formatsize = struct.calcsize(formatcodes)
             pos = 0
             while pos < len(stream):
-                formatcodes = 'HH'
-                formatsize = struct.calcsize(formatcodes)
                 # print('formatsize=%d' % formatsize)
                 opcode, length = struct.unpack(formatcodes, stream[pos:pos+formatsize])
                 # print('opcode=%d length=%d len(stream)=%d' % (opcode, length, len(stream)))

--- a/oletools/thirdparty/oledump/plugin_biff.py
+++ b/oletools/thirdparty/oledump/plugin_biff.py
@@ -1028,15 +1028,16 @@ class cBIFF(object):  # cPluginParent):
             if options.find.startswith('0x'):
                 options.find = binascii.a2b_hex(options.find[2:])
 
-            while len(stream)>0:
+            pos = 0
+            while pos < len(stream):
                 formatcodes = 'HH'
                 formatsize = struct.calcsize(formatcodes)
                 # print('formatsize=%d' % formatsize)
-                opcode, length = struct.unpack(formatcodes, stream[0:formatsize])
+                opcode, length = struct.unpack(formatcodes, stream[pos:pos+formatsize])
                 # print('opcode=%d length=%d len(stream)=%d' % (opcode, length, len(stream)))
-                stream = stream[formatsize:]
-                data = stream[:length]
-                stream = stream[length:]
+                pos += formatsize
+                data = stream[pos:pos+length]
+                pos += length
 
                 if opcode in dOpcodes:
                     opcodename = dOpcodes[opcode]


### PR DESCRIPTION
This code was looping badly with multi-megabyte streams. stream was copied on every iteration, taking around 25 minutes to analyze the whole file. With this patch, the analysis takes around 2 seconds.