### PR TITLE
add json output to olemeta.py

### DIFF
--- a/oletools/olemeta.py
+++ b/oletools/olemeta.py
@@ -62,7 +62,7 @@ __version__ = '0.54'
 
 #=== IMPORTS =================================================================
 
-import sys, os, optparse, collections, json
+import sys, os, optparse, json
 
 # IMPORTANT: it should be possible to run oletools directly as scripts
 # in any directory without installing them with pip or setup.py.


### PR DESCRIPTION
Update olemeta to provide json output with -o flag and to be run imported into other tools.

The olemeta tool works great to provide a table format for interactive use of the tool. I want to be able to import the tool into other scripts to automate some triage of malicious documents. This change would allow the user to provide a -o flag interactively to generate output in json. Normal use of the tool would not change as the default still outputs a table without the -o flag, but it could now be imported into other scripts with something like:

```
import olefile
from oletools import olemeta

with open('file.doc', 'rb') as file:
    output = 'json'
    ole = olefile.OleFileIO(file)
    meta = olemeta.process_ole(ole)
    json_metadata = olemeta.process_output(meta, output)
    print(json_metadata)
```