### PR TITLE
cElementTree has been deprecated since Python 3.3 and removed in Python 3.9

### DIFF
--- a/oletools/olevba.py
+++ b/oletools/olevba.py
@@ -288,12 +288,16 @@ except ImportError:
         import xml.etree.cElementTree as ET
     except ImportError:
         try:
-            # Python <2.5: standalone ElementTree install
-            import elementtree.cElementTree as ET
+            # cElementTree was deprecated and removed in Python 3.9
+            import xml.etree.ElementTree as ET
         except ImportError:
-            raise ImportError("lxml or ElementTree are not installed, " \
-                               + "see http://codespeak.net/lxml " \
-                               + "or http://effbot.org/zone/element-index.htm")
+            try:
+                # Python <2.5: standalone ElementTree install
+                import elementtree.cElementTree as ET
+            except ImportError:
+                raise ImportError("lxml or ElementTree are not installed, " \
+                                  + "see http://codespeak.net/lxml " \
+                                  + "or http://effbot.org/zone/element-index.htm")
 
 import colorclass
 

--- a/oletools/ooxml.py
+++ b/oletools/ooxml.py
@@ -60,7 +60,11 @@ try:
     # lxml: best performance for XML processing
     import lxml.etree as ET
 except ImportError:
-    import xml.etree.cElementTree as ET
+    # cElementTree was deprecated and removed in Python 3.9
+    try:
+        import xml.etree.cElementTree as ET
+    except ImportError:
+        import xml.etree.ElementTree as ET
 
 # -----------------------------------------------------------------------------
 # CHANGELOG:


### PR DESCRIPTION
Fixes #553 