### PR TITLE
Fix: Dridex Strings discrepency in Python 3

### DIFF
--- a/oletools/olevba.py
+++ b/oletools/olevba.py
@@ -402,7 +402,7 @@ def bytes2str(bytes_string, encoding='utf8'):
     :return: the string converted to str
     :rtype: str
     """
-    if PYTHON2:
+    if PYTHON2 or isinstance(bytes_string, str):
         return bytes_string
     else:
         return bytes_string.decode(encoding, errors='replace')
@@ -2277,17 +2277,17 @@ def StripCharsWithZero (input) :
 
 def DridexUrlDecode (inputText) :
     work = inputText[4:-4]
-    strKeyEnc = StripCharsWithZero(work[(len(work) / 2) - 2: (len(work) / 2)])
-    strKeySize = StripCharsWithZero(work[(len(work) / 2): (len(work) / 2) + 2])
+    strKeyEnc = StripCharsWithZero(work[(len(work) // 2) - 2: (len(work) // 2)])
+    strKeySize = StripCharsWithZero(work[(len(work) // 2): (len(work) // 2) + 2])
     nCharSize = strKeySize - strKeyEnc
-    work = work[:(len(work) / 2) - 2] + work[(len(work) / 2) + 2:]
-    strKeyEnc2 = StripChars(work[(len(work) / 2) - (nCharSize/2): (len(work) / 2) + (nCharSize/2)])
-    work = work[:(len(work) / 2) - (nCharSize/2)] + work[(len(work) / 2) + (nCharSize/2):]
+    work = work[:(len(work) // 2) - 2] + work[(len(work) // 2) + 2:]
+    strKeyEnc2 = StripChars(work[(len(work) // 2) - (nCharSize//2): (len(work) // 2) + (nCharSize//2)])
+    work = work[:(len(work) // 2) - (nCharSize//2)] + work[(len(work) // 2) + (nCharSize//2):]
     work_split = [work[i:i+nCharSize] for i in range(0, len(work), nCharSize)]
     decoded = ''
     for group in work_split:
         # sys.stdout.write(chr(StripChars(group)/strKeyEnc2))
-        decoded += chr(StripChars(group)/strKeyEnc2)
+        decoded += chr(StripChars(group)//strKeyEnc2)
     return decoded
 
 # DridexUrlDecode("C3iY1epSRGe6q8g15xStVesdG717MAlg2H4hmV1vkL6Glnf0cknj")


### PR DESCRIPTION
* Fixes #478

#### Before PR:
Python 2:
> (python2) [zdiff@localhost oletools]$ python oletools/olevba.py --decode --deobf --reveal ae2ef8f792e2f17a52208ff52dd493fa090ce82c20253138ebf770ad4626989c | grep Dridex
|Suspicious|Dridex Strings      |Dridex-encoded strings were detected, may be |
|Dridex    |'\x00'              |HA6Ly9jb3N0ZmVyLnBsL2ZpbGUvb2Z0LmdmZCxod     |

Python 3:
> (python3) [zdiff@localhost oletools]$ python oletools/olevba.py --decode --deobf --reveal ae2ef8f792e2f17a52208ff52dd493fa090ce82c20253138ebf770ad4626989c | grep Dridex | wc -l
0

#### After PR:
Python 2:
> (python2) [zdiff@localhost oletools]$ python -V
Python 2.7.17
(python2) [zdiff@localhost oletools]$ python oletools/olevba.py --decode --deobf --reveal ae2ef8f792e2f17a52208ff52dd493fa090ce82c20253138ebf770ad4626989c | grep Dridex
|Suspicious|Dridex Strings      |Dridex-encoded strings were detected, may be |
|Dridex    |'\x00'              |HA6Ly9jb3N0ZmVyLnBsL2ZpbGUvb2Z0LmdmZCxod     |

Python 3:
>(python3) [zdiff@localhost oletools]$ python -V
Python 3.7.6
(python3) [zdiff@localhost oletools]$ python oletools/olevba.py --decode --deobf --reveal ae2ef8f792e2f17a52208ff52dd493fa090ce82c20253138ebf770ad4626989c | grep Dridex
|Suspicious|Dridex Strings      |Dridex-encoded strings were detected, may be |
|Dridex    |'\x00'              |HA6Ly9jb3N0ZmVyLnBsL2ZpbGUvb2Z0LmdmZCxod     |

---
#### Explanation

![image](https://user-images.githubusercontent.com/19849963/79673563-c6526980-81a8-11ea-97e2-2130e205ec53.png)

*Python 2* and *Python 3* handle the `/` operator differently.

In *Python 2*,  If both operands are of type `int`, floor division is performed and an `int` is returned. If either operand is a `float`, classic division is performed and a `float` is returned. The `//` operator is also provided for doing floor division no matter what the operands are. 

In *Python 3*, Division always returns a float. To do floor division and get an integer result (discarding any fractional result) you can use the `//` operator



Python 2 Example:
```bash
Python 2.7.17 (default, Oct 20 2019, 00:00:00) 
[GCC 9.2.1 20190827 (Red Hat 9.2.1-1)] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> 5 / 2
2
>>> 5 // 2
2
```

Python 3 Example:
```
Python 3.7.6 (default, Dec 19 2019, 22:52:49) 
[GCC 9.2.1 20190827 (Red Hat 9.2.1-1)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> 5 / 2
2.5
>>> 5 // 2
2
```