### PR TITLE
Added simple check to see if oleobject is obfuscated

### DIFF
--- a/oletools/rtfobj.py
+++ b/oletools/rtfobj.py
@@ -644,6 +644,7 @@ class RtfObject(object):
         # Additional OLE object data
         self.clsid = None
         self.clsid_desc = None
+        self.was_obfuscated = False
 
 
 
@@ -670,6 +671,7 @@ class RtfObjParser(RtfParser):
             self.objects.append(rtfobj)
             rtfobj.start = destination.start
             rtfobj.end = destination.end
+            rtfobj.was_obfuscated = len(destination.data) != destination.end - destination.start
             # Filter out all whitespaces first (just ignored):
             hexdata1 = destination.data.translate(None, b' \t\r\n\f\v')
             # Then filter out any other non-hex character:
@@ -905,6 +907,8 @@ def process_file(container, filename, data, output_dir=None, save_object=False):
                     ole_column += '\nEXECUTABLE FILE'
             else:
                 ole_column += '\nMD5 = %r' % rtfobj.oledata_md5
+            if rtfobj.was_obfuscated:
+                ole_column += '\nObfuscation detected in RTF OLE Object'
             if rtfobj.clsid is not None:
                 ole_column += '\nCLSID: %s' % rtfobj.clsid
                 ole_column += '\n%s' % rtfobj.clsid_desc


### PR DESCRIPTION
Added check for if OLE object data is smaller than the difference between the
start and end index. This doesn't count whitespaces since these
may be added for formating by legitimate service.

If obfuscation is found then it will print
"Obfuscation detected in RTF OLE Object" in the ole column

This can be useful for hunting for new malicious activity if the attacker tries to obfuscate the OLE object. 

![analyst-2020-06-20-00-23-28](https://user-images.githubusercontent.com/16967002/85196176-263ebc80-b28d-11ea-8527-74006b764772.png)
