### PR TITLE
fixed command line option --relaxed

### DIFF
--- a/oletools/olevba.py
+++ b/oletools/olevba.py
@@ -2062,7 +2062,7 @@ def _extract_vba(ole, vba_root, project_path, dir_path, relaxed=False):
     """
     log.debug('relaxed is %s' % relaxed)
 
-    project = VBA_Project(ole, vba_root, project_path, dir_path, relaxed=False)
+    project = VBA_Project(ole, vba_root, project_path, dir_path, relaxed)
     project.parse_project_stream()
 
     for code_path, filename, code_data in project.parse_modules():


### PR DESCRIPTION
during object initialization relaxed was set to False all the time, regardless of the command line option.