### PR TITLE
Fix escaping errors

### DIFF
--- a/oletools/rtfobj.py
+++ b/oletools/rtfobj.py
@@ -264,7 +264,7 @@ DELIMITER = b'[ \\t\\r\\n\\f\\v]'
 DELIMITERS_ZeroOrMore = b'[ \\t\\r\\n\\f\\v]*'
 BACKSLASH_BIN = b'\\\\bin'
 # According to my tests, Word accepts up to 250 digits (leading zeroes)
-DECIMAL_GROUP = b'(\d{1,250})'
+DECIMAL_GROUP = b'(\\d{1,250})'
 
 re_delims_bin_decimal = re.compile(DELIMITERS_ZeroOrMore + BACKSLASH_BIN
                                    + DECIMAL_GROUP + DELIMITER)

--- a/oletools/thirdparty/prettytable/prettytable.py
+++ b/oletools/thirdparty/prettytable/prettytable.py
@@ -71,7 +71,7 @@ MSWORD_FRIENDLY = 11
 PLAIN_COLUMNS = 12
 RANDOM = 20
 
-_re = re.compile("\033\[[0-9;]*m")
+_re = re.compile("\033\\[[0-9;]*m")
 
 def _get_size(text):
     lines = text.split("\n")
@@ -797,9 +797,9 @@ class PrettyTable(object):
         self._vrules = random.choice((ALL, FRAME, NONE))
         self.left_padding_width = random.randint(0,5)
         self.right_padding_width = random.randint(0,5)
-        self.vertical_char = random.choice("~!@#$%^&*()_+|-=\{}[];':\",./;<>?")
-        self.horizontal_char = random.choice("~!@#$%^&*()_+|-=\{}[];':\",./;<>?")
-        self.junction_char = random.choice("~!@#$%^&*()_+|-=\{}[];':\",./;<>?")
+        self.vertical_char = random.choice("~!@#$%^&*()_+|-=\\{}[];':\",./;<>?")
+        self.horizontal_char = random.choice("~!@#$%^&*()_+|-=\\{}[];':\",./;<>?")
+        self.junction_char = random.choice("~!@#$%^&*()_+|-=\\{}[];':\",./;<>?")
 
     ##############################
     # DATA INPUT METHODS         #


### PR DESCRIPTION
There are several escaping errors present in the project, and those are now fixed by adding an additional backslash where necessary.

Note that this will only impact a future release of Python, as stated on https://docs.python.org/3.9/reference/lexical_analysis.html:

> Unlike Standard C, all unrecognized escape sequences are left in the string unchanged, i.e., the backslash is left in the result. (This behavior is useful when debugging: if an escape sequence is mistyped, the resulting output is more easily recognized as broken.) It is also important to note that the escape sequences only recognized in string literals fall into the category of unrecognized escapes for bytes literals.
> 
> Changed in version 3.6: Unrecognized escape sequences produce a DeprecationWarning. In a future Python version they will be a SyntaxWarning and eventually a SyntaxError.