### PR TITLE
olevba: add formula run to cBIFF

### DIFF
--- a/oletools/olevba.py
+++ b/oletools/olevba.py
@@ -3351,6 +3351,9 @@ class VBA_Parser(object):
                         self.xlm_macros += biff_plugin.Analyze()
                         biff_plugin = cBIFF(name=[excel_stream], stream=data, options='-c -r LN')
                         self.xlm_macros += biff_plugin.Analyze()
+                        # try to extract keywords from FORMULAs
+                        biff_plugin = cBIFF(name=[excel_stream], stream=data, options='-o FORMULA -r LN')
+                        self.xlm_macros += biff_plugin.Analyze()
                         # we run plugin_biff again, this time to search DCONN objects and get their URLs, if any:
                         # ref: https://inquest.net/blog/2020/03/18/Getting-Sneakier-Hidden-Sheets-Data-Connections-and-XLM-Macros
                         biff_plugin = cBIFF(name=[excel_stream], stream=data, options='-o DCONN -s')


### PR DESCRIPTION
Explicitly analyze formulas in XLM Macros. It seems this commit is the root cause. https://github.com/decalage2/oletools/commit/1624ef07959340e49ffdf27f5fac49c73c0760a0
Maybe more good cbiff options are omitted now?

https://app.any.run/tasks/ab1be06f-c760-4b51-b0ba-1d37f6e59a38/

[xlm_formula_exec.zip](https://github.com/decalage2/oletools/files/5372638/xlm_formula_exec.zip) (infected)
