### PR TITLE
Possible fix for extended ASCII issue (#490)

### DIFF
--- a/oletools/olevba.py
+++ b/oletools/olevba.py
@@ -4608,7 +4608,6 @@ def main(cmd_line_args=None):
     sys.exit(return_code)
 
 if __name__ == '__main__':
-    print("MODIFIED!!")
     main()
 
 # This was coded while listening to "Dust" from I Love You But I've Chosen Darkness

--- a/oletools/olevba.py
+++ b/oletools/olevba.py
@@ -388,11 +388,10 @@ def unicode2str(unicode_string):
     :return: the string converted to str
     :rtype: str
     """
-    # Unicode conversion does nasty things to VBA extended ASCII
-    # characters. VBA payload decode routines work correctly with the
-    # raw byte values in payload strings in the decompressed VBA, so leave
-    # strings alone.
-    return unicode_string
+    if PYTHON2:
+        return unicode_string.encode('utf8', errors='replace')
+    else:
+        return unicode_string
 
 
 def bytes2str(bytes_string, encoding='utf8'):
@@ -1634,10 +1633,12 @@ class VBA_Module(object):
                 code_data = decompress_stream(bytearray(code_data))
                 # store the raw code encoded as bytes with the project's code page:
                 self.code_raw = code_data
-                # decode it to unicode:
-                self.code = project.decode_bytes(code_data)
-                # also store a native str version:
-                self.code_str = unicode2str(self.code)
+                # Unicode conversion does nasty things to VBA extended ASCII
+                # characters. VBA payload decode routines work correctly with the
+                # raw byte values in payload strings in the decompressed VBA, so leave
+                # strings alone.
+                self.code = project.fix_bytes(code_data)
+                self.code_str = self.code
                 # case-insensitive search in the code_modules dict to find the file extension:
                 filext = self.project.module_ext.get(self.name.lower(), 'vba')
                 self.filename = u'{0}.{1}'.format(self.name, filext)
@@ -2083,11 +2084,14 @@ class VBA_Project(object):
         :param errors: str, mode to handle unicode conversion errors
         :return: str/unicode, decoded string
         """
-
-        # Unicode conversion does nasty things to VBA extended ASCII
-        # characters. VBA payload decode routines work correctly with the
-        # raw byte values in payload strings in the decompressed VBA, so leave
-        # strings alone.
+        return bytes_string.decode(self.codec, errors=errors)
+    
+    def fix_bytes(self, bytes_string):
+        """
+        Change the escaping (value) of a few characters in decompressed VBA code.
+        :param bytes_string: bytes, bytes string to be fixed
+        :return: bytes, fixed string
+        """
         s = ""
         in_str = False
         for b in bytes_string:


### PR DESCRIPTION
This is a potential fix for https://github.com/decalage2/oletools/issues/490 . Based on the behavior of oledump and some VBA payload decoders that decode extended ASCII strings it looks like VBA code bytes should be left unmodified after they have been decompressed, so no unicode string conversion. The unicode conversion attempts to do something smart and useful with the "special" Office extended VBA characters, which results in these single byte extended ASCII characters being converted to multi-byte unicode characters, which breaks the VBA payload decoders.

Additionally, if you loop through a string with extended ASCII characters in VBA, pull out each character with Mid(), and then print the characters with Debug.Print the original single byte extended ASCII character is printed (i.e. what you get from the initial decompressed VBA stream prior to unicode conversion).