### PR TITLE
oleobj: Missing commas in BLACKLISTED_RELATIONSHIP_TYPES

### DIFF
--- a/oletools/oleobj.py
+++ b/oletools/oleobj.py
@@ -212,8 +212,8 @@ BLACKLISTED_RELATIONSHIP_TYPES = [
     'attachedTemplate',
     'externalLink',
     'externalLinkPath',
-    'externalReference'
-    'frame'
+    'externalReference',
+    'frame',
     'hyperlink',
     'officeDocument',
     'oleObject',


### PR DESCRIPTION
Hello @decalage2,

Thank you for this great tool.

I recently came across this sample which has a relationship, with 'frame' as external link (sha256: 6a5d70c47d314c310003fcd0d74295d2442a27a5de87aedef715e426aa7222bd)

Expected extraction: http://filecopying[.]xyz/KB234520/update/2107SP

However, due to missing commas in the BLACKLISTED_RELATIONSHIP_TYPES, this link is missed. Someone already reported this issue #641 

Please accept the PR, and let me know if you have any comments. Thank you!