### PR TITLE
ensure uppercase KNOWN_CLSIDS matching

### DIFF
--- a/oletools/common/clsid.py
+++ b/oletools/common/clsid.py
@@ -66,10 +66,10 @@ KNOWN_CLSIDS = {
     '00000306-0000-0000-C000-000000000046': 'Pointer Moniker',
     '00000308-0000-0000-C000-000000000046': 'Packager Moniker',
     '00000309-0000-0000-C000-000000000046': 'Composite Moniker (may trigger CVE-2017-8570)',
-    '0000031a-0000-0000-C000-000000000046': 'Class Moniker',
+    '0000031A-0000-0000-C000-000000000046': 'Class Moniker',
     '00000535-0000-0010-8000-00AA006D2EA4': 'ADODB.RecordSet (may trigger CVE-2015-0097)',
-    '0002034c-0000-0000-C000-000000000046': 'OutlookAttachMoniker',
-    '0002034e-0000-0000-C000-000000000046': 'OutlookMessageMoniker',
+    '0002034C-0000-0000-C000-000000000046': 'OutlookAttachMoniker',
+    '0002034E-0000-0000-C000-000000000046': 'OutlookMessageMoniker',
     '00020810-0000-0000-C000-000000000046': 'Microsoft Excel.Sheet.5',
     '00020811-0000-0000-C000-000000000046': 'Microsoft Excel.Chart.5',
     '00020820-0000-0000-C000-000000000046': 'Microsoft Microsoft Excel 97-2003 Worksheet (Excel.Sheet.8)',
@@ -79,7 +79,7 @@ KNOWN_CLSIDS = {
     '00020833-0000-0000-C000-000000000046': 'Microsoft Excel binary sheet with macro enabled (Excel.SheetBinaryMacroEnabled.12)',
     '00020900-0000-0000-C000-000000000046': 'Microsoft Word 6.0-7.0 Document (Word.Document.6)',
     '00020906-0000-0000-C000-000000000046': 'Microsoft Word 97-2003 Document (Word.Document.8)',
-    '00020907-0000-0000-c000-000000000046': 'Microsoft Word Picture (Word.Picture.8)',
+    '00020907-0000-0000-C000-000000000046': 'Microsoft Word Picture (Word.Picture.8)',
     '00020C01-0000-0000-C000-000000000046': 'OLE Package Object (may contain and run any file)',
     '00021401-0000-0000-C000-000000000046': 'Windows LNK Shortcut file', # ref: https://github.com/libyal/liblnk/blob/master/documentation/Windows%20Shortcut%20File%20(LNK)%20format.asciidoc
     '00021700-0000-0000-C000-000000000046': 'Microsoft Equation 2.0 (Known Related to CVE-2017-11882 or CVE-2018-0802)',
@@ -180,8 +180,8 @@ KNOWN_CLSIDS = {
     'D93CE8B5-3BF8-462C-A03F-DED2730078BA': 'Loads WUAEXT.DLL (Known Related to CVE-2015-6128)',
     'DD9DA666-8594-11D1-B16A-00C0F0283628': 'MSCOMCTL.ImageComboCtrl (may trigger CVE-2014-1761)',
     # Referenced in https://resources.sei.cmu.edu/library/asset-view.cfm?assetid=652438 :
-    'DF630910-1C1D-11d0-AE36-8C0F5E000000': 'pythoncomloader27.dll (related to CVE-2021-27058)',
-    'DFEAF541-F3E1-4c24-ACAC-99C30715084A': 'Silverlight Objects',
+    'DF630910-1C1D-11D0-AE36-8C0F5E000000': 'pythoncomloader27.dll (related to CVE-2021-27058)',
+    'DFEAF541-F3E1-4C24-ACAC-99C30715084A': 'Silverlight Objects',
     'E5CA59F5-57C4-4DD8-9BD6-1DEEEDD27AF4': 'InkEd.InkEdit',
     'E8CC4CBE-FDFF-11D0-B865-00A0C9081C1D': 'MSDAORA.1 (potential exploit CVE TODO)', # TODO
     'E8CC4CBF-FDFF-11D0-B865-00A0C9081C1D': 'Loads OCI.DLL (Known Related to CVE-2015-6128)',

--- a/oletools/oledir.py
+++ b/oletools/oledir.py
@@ -125,8 +125,9 @@ def sid_display(sid):
         return sid
 
 def clsid_display(clsid):
-    if clsid in KNOWN_CLSIDS:
-        clsid += '\n%s' % KNOWN_CLSIDS[clsid]
+    clsid_upper = clsid.upper()
+    if clsid_upper in KNOWN_CLSIDS:
+        clsid += '\n%s' % KNOWN_CLSIDS[clsid_upper]
     color = 'yellow'
     if 'CVE' in clsid:
         color = 'red'

--- a/oletools/rtfobj.py
+++ b/oletools/rtfobj.py
@@ -710,7 +710,7 @@ class RtfObjParser(RtfParser):
                     if olefile.isOleFile(obj.data):
                         ole = olefile.OleFileIO(obj.data)
                         rtfobj.clsid = ole.root.clsid
-                        rtfobj.clsid_desc = clsid.KNOWN_CLSIDS.get(rtfobj.clsid,
+                        rtfobj.clsid_desc = clsid.KNOWN_CLSIDS.get(rtfobj.clsid.upper(),
                             'unknown CLSID (please report at https://github.com/decalage2/oletools/issues)')
             except:
                 pass

--- a/tests/common/test_clsid.py
+++ b/tests/common/test_clsid.py
@@ -1,0 +1,11 @@
+import unittest
+
+from oletools.common.clsid import KNOWN_CLSIDS
+
+
+class TestCommonClsid(unittest.TestCase):
+
+    def test_known_clsids_uppercase(self):
+        for k, v in KNOWN_CLSIDS.items():
+            k_upper = k.upper()
+            self.assertEqual(k, k_upper)


### PR DESCRIPTION
This change set ensures that lookups for known class identifiers are always performed with uppercase strings.

An additional unit test ensures that all identifiers are in uppercase only. 