### PR TITLE
Fixes OleID constructor

### DIFF
--- a/oletools/oleid.py
+++ b/oletools/oleid.py
@@ -235,6 +235,8 @@ class OleID(object):
             self.file_on_disk = True  # useful for some check that don't work in memory
             with open(filename, 'rb') as f:
                 self.data = f.read()
+        else:
+            self.data = data
         self.data_bytesio = io.BytesIO(self.data)
         if isinstance(filename, olefile.OleFileIO):
             self.ole = filename


### PR DESCRIPTION
It's necessary to set self.data if data is not None.

Fixes: #695

Signed-off-by: Jürgen Löhel <juergen.loehel@inlyse.com>