### PR TITLE
add comment delete function

### DIFF
--- a/oletools/mraptor.py
+++ b/oletools/mraptor.py
@@ -183,6 +183,8 @@ class MacroRaptor(object):
         """
         # collapse long lines first
         self.vba_code = olevba.vba_collapse_long_lines(vba_code)
+        # delete comments
+        self.vba_code = olevba.vba_delete_comments(vba_code)
         self.autoexec = False
         self.write = False
         self.execute = False

--- a/oletools/olevba.py
+++ b/oletools/olevba.py
@@ -2135,6 +2135,26 @@ def vba_collapse_long_lines(vba_code):
     return vba_code
 
 
+def vba_delete_comments(vba_code):
+    """
+    Parse a VBA module code to remove the comments.
+
+    :param vba_code: str, VBA module code
+    :return: str, VBA module code without comments
+    """
+    formit_lines = []
+    for code_line in vba_code.splitlines():
+        new_line = ''
+        for char in code_line:
+            if char != "'":
+                new_line += char
+            else:
+                break
+        formit_lines.append(new_line)
+    vba_code = '\r\n'.join(formit_lines)
+    return vba_code
+
+
 def filter_vba(vba_code):
     """
     Filter VBA source code to remove the first lines starting with "Attribute VB_",


### PR DESCRIPTION
I find that your vba_code initialisation module does not do what it should do with comments, which makes it easy to treat text content as code and is highly prone to false positives.

So I add a module in oletools/olevba.py to delete the comments in vba_code.