### PR TITLE
olevba: fix sys.argv[1] using xlmdeobfuscator

### DIFF
--- a/oletools/olevba.py
+++ b/oletools/olevba.py
@@ -3421,7 +3421,7 @@ class VBA_Parser(object):
         xlm += result
         xlm.append('- ' * 38)
         xlm.append('EMULATION - DEOBFUSCATED EXCEL4/XLM MACRO FORMULAS:')
-        result = xlmdeobfuscator.process_file(file=sys.argv[1],
+        result = xlmdeobfuscator.process_file(file=self.filename,
                                            noninteractive=True,
                                            noindent=True,
                                            # output_formula_format='CELL:[[CELL_ADDR]], [[INT-FORMULA]]',


### PR DESCRIPTION
When I parse xlm macro from external software using olevba, I found a bug in the following line.

https://github.com/decalage2/oletools/blob/412ee36ae45e70f42123e835871bac956d958461/oletools/olevba.py#L3424-L3430

In order to make it available from external software, I changed the call to be the same as line 3409: 

https://github.com/decalage2/oletools/blob/412ee36ae45e70f42123e835871bac956d958461/oletools/olevba.py#L3409