### PR TITLE
Change addressing #749

### DIFF
--- a/oletools/olevba.py
+++ b/oletools/olevba.py
@@ -3655,8 +3655,10 @@ class VBA_Parser(object):
             # variable to merge source code from all modules:
             if self.vba_code_all_modules is None:
                 self.vba_code_all_modules = self.get_vba_code_all_modules()
+                strings = []
                 for (_, _, form_string) in self.extract_form_strings():
-                    self.vba_code_all_modules += form_string + '\n'
+                    strings.append(form_string)
+                self.vba_code_all_modules.join(strings)
             # Analyze the whole code at once:
             scanner = VBA_Scanner(self.vba_code_all_modules)
             self.analysis_results = scanner.scan(show_decoded_strings, deobfuscate)


### PR DESCRIPTION
When an input file has on the order of ~100,000s of strings, `analyze_macros()` becomes very slow. Let's change this behavior to instead store extracted strings in their own structure, and add them to the module source afterwards instead of incrementally.

Example with input file 4a87ee5ecd46a3fab735656b77d0e4fea8d3d72f3a6e0fb791999a2dfe8d59d2 (available on VirusTotal), using Python 3.9.10 on macOS:
Time performance without this patch: `python3 ./oletools/olevba.py  > /dev/null  929.50s user 1896.56s system 58% cpu 1:20:32.49 total`
Time performance with this patch: `python3 ./oletools/olevba.py  > /dev/null  5.81s user 2.43s system 95% cpu 8.605 total`