### PR TITLE
ftguess: Handle error when [Content_Types].xml is not present.

### DIFF
--- a/oletools/ftguess.py
+++ b/oletools/ftguess.py
@@ -435,7 +435,7 @@ class FType_Generic_OpenXML(FType_Base):
         # parse content types, find content type of main part
         try:
             content_types = ftg.zipfile.read('[Content_Types].xml')
-        except RuntimeError:
+        except (RuntimeError, KeyError):
             return False
         # parse the XML content
         # TODO: handle XML parsing exceptions


### PR DESCRIPTION
I came across some files where this XML was named `[Content_Types].xmla`. It's strange suffix, MS Word does not open it and `ftguess` crashes with `KeyError`.

Have you ever seen such files? The other option would be to support analysis even for `xmla` content types. It's up to you.
I'm mostly interested in non-crashing `olevba` so this is a hotfix. If you think we should handle such files differently, let me know or feel free to implement it yourself and close this PR :)