### PR TITLE
Fix a SyntaxWarning in Python 3.8+

### DIFF
--- a/oletools/oleobj.py
+++ b/oletools/oleobj.py
@@ -578,7 +578,7 @@ def get_sane_embedded_filenames(filename, src_path, tmp_path, max_len,
 
         # identify suffix. Dangerous suffixes are all short
         idx = candidate.rfind('.')
-        if idx is -1:
+        if idx == -1:
             candidates_without_suffix.append(candidate)
             continue
         elif idx < len(candidate)-5:


### PR DESCRIPTION
Python 3.8+ now produces a SyntaxWarning when identify checks are used with certain literals. This was documented in the 3.8 release notes here https://docs.python.org/3/whatsnew/3.8.html#porting-to-python-3-8

On import, the oletools package currently produces a such a warning message:

```
/usr/local/lib/python3.8/dist-packages/oletools/oleobj.py:581: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if idx is -1:
```

This PR changes the identify check to a equality check.