### PR TITLE
Update oleform to fix a padding bug and add an enhancement

### DIFF
--- a/oletools/oleform.py
+++ b/oletools/oleform.py
@@ -310,20 +310,20 @@ def consume_OleSiteConcreteControl(stream):
         # SiteExtraDataBlock: [MS-OFORMS] 2.2.10.12.4
         name = None
         if (name_len > 0):
-            name = stream.read(name_len)
-        # Consume 2 null bytes between name and tag.
-        #if ((tag_len > 0) or (control_tip_text_len > 0)):
-        #    stream.read(2)
-        #    # Sometimes it looks like 2 extra null bytes go here whether or not there is a tag.
+            with stream.will_pad():
+                name = stream.read(name_len)
         tag = None
         if (tag_len > 0):
-            tag = stream.read(tag_len)
+            with stream.will_pad():
+                tag = stream.read(tag_len)
         # Skip SitePosition.
         if propmask.fPosition:
             stream.read(8)
-        control_tip_text = stream.read(control_tip_text_len)
-        if (len(control_tip_text) == 0):
+        if (control_tip_text_len == 0):
             control_tip_text = None
+        else:
+            with stream.will_pad():
+                control_tip_text = stream.read(control_tip_text_len)
         return {'name': name, 'tag': tag, 'id': id, 'tabindex': tabindex,
                 'ClsidCacheIndex': ClsidCacheIndex, 'value': None, 'caption': None,
                 'control_tip_text':control_tip_text}
@@ -400,15 +400,20 @@ def consume_MorphDataControl(stream):
         # MorphDataExtraDataBlock: [MS-OFORMS] 2.2.5.4
         # Discard Size
         stream.read(8)
-        value = stream.read(value_size)
+        value = ""
+        if (value_size > 0):
+            with stream.will_pad():        
+                value = stream.read(value_size)
         # Read caption text.
         caption = ""
         if (caption_size > 0):
-            caption = stream.read(caption_size)
+            with stream.will_pad():
+                caption = stream.read(caption_size)
         # Read groupname text.
         group_name = ""
         if (group_name_size > 0):
-            group_name = stream.read(group_name_size)
+            with stream.will_pad():
+                group_name = stream.read(group_name_size)
             
     # MorphDataStreamData: [MS-OFORMS] 2.2.5.5
     if propmask.fMouseIcon:
@@ -502,7 +507,10 @@ def consume_LabelControl(stream):
                                       ('fSpecialEffect', 2), ('fPicture', 2),
                                       ('fAccelerator', 2), ('fMouseIcon', 2)])
         # LabelExtraDataBlock: [MS-OFORMS] 2.2.4.4
-        caption = stream.read(caption_size)
+        caption = ""
+        if (caption_size > 0):
+            with stream.will_pad():
+                caption = stream.read(caption_size)
         stream.read(8)
     # LabelStreamData: [MS-OFORMS] 2.2.4.5
     if propmask.fPicture:

--- a/oletools/oleform.py
+++ b/oletools/oleform.py
@@ -73,7 +73,7 @@ class FormPropMask(Mask):
     """FormPropMask: [MS-OFORMS] 2.2.10.2"""
     _size = 28
     _names = ['Unused1', 'fBackColor', 'fForeColor', 'fNextAvailableID', 'Unused2_0', 'Unused2_1',
-              'fBooleanProperties', 'fBooleanProperties', 'fMousePointer', 'fScrollBars',
+              'fBooleanProperties', 'fBorderStyle', 'fMousePointer', 'fScrollBars',
               'fDisplayedSize', 'fLogicalSize', 'fScrollPosition', 'fGroupCnt', 'Reserved',
               'fMouseIcon', 'fCycle', 'fSpecialEffect', 'fBorderColor', 'fCaption', 'fFont',
               'fPicture', 'fZoom', 'fPictureAlignment', 'fPictureTiling', 'fPictureSizeMode',


### PR DESCRIPTION
This PR includes one bug fix and one enhancement addition.

1. The properties of type String are stored in OLE form stream with a padding of multiples of four bytes as mentioned in [MS-OFORMS section 2.1.1.2.4 - Padding and Alignment](https://interoperability.blob.core.windows.net/files/MS-OFORMS/[MS-OFORMS].pdf#%5B%7B%22num%22%3A117%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C69%2C641%2C0%5D). Various properties which are of type String (specifically fmString) such as Name, ControlTipText, Caption etc. were being read in oleform without accounting for this padding. This often lead to prepending of 1-3 to junk bytes at the start of extracted value (and discarded an equal number of valid bytes at the end of value). 1b2cf45f7d40413d73a7c30b9660a45c0d5cf636 fixes this bug by using `stream.will_pad()` whenever a String value is read.

2. Controls having ClsidCacheIndex = 14, called Frame control, can have child controls embedded in them while the control itself is embedded in a parent control. In such cases, an i _n_ child stream exists within the parent stream directory - n being the ID of the Frame control. This is described in [section 2.1.2.2.2 - Embedded Parents](https://interoperability.blob.core.windows.net/files/MS-OFORMS/[MS-OFORMS].pdf#%5B%7B%22num%22%3A123%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C69%2C401%2C0%5D). This i stream may contain certain properties such as Caption of the Frame Control. fd0f0c5bba5e9dd0742ee49ac672d114609587f5 adds a function `consume_EmbeddedFormControl()` to extract Caption property in such cases for Frame controls. This commit also relies on bc7c53f038c69b2aa707e319639c7d5f479fba08 which fixes a minor bug in `FormPropMask _names` list.

More information and context around these changes can be found in my [blog post](https://nvdp01.github.io/analysis/2022/06/29/extracting-vba-userform-field-values.html).
