### PR TITLE
tests: Re-enable samples skipped because of #215

### DIFF
--- a/tests/test_utils/__init__.py
+++ b/tests/test_utils/__init__.py
@@ -1,1 +1,2 @@
 from .utils import *
+from .testdata_reader import *


### PR DESCRIPTION
Some samples triggered antivirus engines, issues #215 and #217 ended with the agreement to encapsulate problematic samples in encrypted zip containers and decrypt them on-the-fly. Initial support for this was added but that did not cover 5 tests. Create on-the-fly decryption for these tests as well and re-enable them.