### PR TITLE
Fix xlm_macro false positive

### DIFF
--- a/oletools/olevba.py
+++ b/oletools/olevba.py
@@ -3448,6 +3448,7 @@ class VBA_Parser(object):
                         return True
                 except:
                     log.exception('Error when running oledump.plugin_biff, please report to %s' % URL_OLEVBA_ISSUES)
+        self.xlm_macros = []
         self.contains_xlm_macros = False
         return False
 


### PR DESCRIPTION
_extract_xlm_plugin_biff adds xlm_macro even if there is no Excel 4.0 macro sheet exist