### PR TITLE
Relax pyparsing requirement. 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pyparsing>=2.1.0,<3
+pyparsing>=2.1.0,<4
 olefile>=0.46
 easygui
 colorclass

--- a/setup.py
+++ b/setup.py
@@ -320,7 +320,7 @@ def main():
         test_suite="tests",
         # scripts=scripts,
         install_requires=[
-            "pyparsing>=2.1.0,<3",  # changed from 2.2.0 to 2.1.0 for issue #481
+            "pyparsing>=2.1.0,<4",  # changed from 2.2.0 to 2.1.0 for issue #481
             "olefile>=0.46",
             "easygui",
             'colorclass',


### PR DESCRIPTION
All oletools unit tests pass with pyparsing 3.0.9 installed.
This makes it easier to use oletools as a library.