### PR TITLE
add hint about existing parameter when stomping is detected

### DIFF
--- a/oletools/olevba.py
+++ b/oletools/olevba.py
@@ -3645,7 +3645,7 @@ class VBA_Parser(object):
                 log.debug('adding VBA stomping to suspicious keywords')
                 keyword = 'VBA Stomping'
                 description = 'VBA Stomping was detected: the VBA source code and P-code are different, '\
-                    'this may have been used to hide malicious code'
+                    'this may have been used to hide malicious code (option --show-pcode to show disassembled P-code)'
                 scanner.suspicious_keywords.append((keyword, description))
                 scanner.results.append(('Suspicious', keyword, description))
             if self.contains_xlm_macros:


### PR DESCRIPTION
The other day I was analyzing a file and olevba detected VBA stomping. Only after researching I found out that olevba already has a tool included for showing the disassembled P-Code.
Therefor I suggest adding a hint so that others know about the existing parameter.