### PR TITLE
handle new record in new vbaproject.bin if present

### DIFF
--- a/oletools/olevba.py
+++ b/oletools/olevba.py
@@ -1704,6 +1704,13 @@ class VBA_Project(object):
         # PROJECTLCID Record
         # Specifies the VBA project's LCID.
         projectlcid_id = struct.unpack("<H", dir_stream.read(2))[0]
+        # In newer versions the dir stream PROJECTINFORMATION record contains a
+        # new CompatVersionRecord (10 bytes) at this location, with ID 0x004A.
+        # If that ID is encountered, skip the remaining 8 bytes of this block and
+        # read the next 2 bytes which should contain PROJECTLCID_Id.
+        if projectlcid_id == 0x004A:
+            unused = dir_stream.read(8)
+            projectlcid_id = struct.unpack("<H", dir_stream.read(2))[0]
         self.check_value('PROJECTLCID_Id', 0x0002, projectlcid_id)
         projectlcid_size = struct.unpack("<L", dir_stream.read(4))[0]
         self.check_value('PROJECTLCID_Size', 0x0004, projectlcid_size)


### PR DESCRIPTION
In one of the recent updates to the MS-OVBA Office VBA File Format Structure specs, a new 10-byte CompatVersionRecord block was added to the PROJECTINFORMATION block:

![image](https://github.com/decalage2/oletools/assets/20178486/3bdf8480-d0b4-48e3-b282-cf6fc2cbc70e)
![image](https://github.com/decalage2/oletools/assets/20178486/e7ea81cc-a49a-4c52-ad80-5cf1b67c9983)

The record is identified with id 0x004A:

![image](https://github.com/decalage2/oletools/assets/20178486/c562d09b-bf82-4979-940c-1374bad085e2)

The insertion of this new record leads to corrupt/failed parsing of the remainder of the PROJECTINFORMATION record. For my use case this was the source of this issue: https://github.com/decalage2/oletools/issues/811.

Adding a conditional check to skip over this new 10-byte record if encountered resolved the issue for me. This is a pretty targeted/brittle solution...I'm not sure if there is a more robust route (this was my first time actually diving into the file format).