### PR TITLE
Add "Modules" as keyword for self-modification

### DIFF
--- a/oletools/olevba.py
+++ b/oletools/olevba.py
@@ -806,7 +806,7 @@ SUSPICIOUS_KEYWORDS = {
         ('AccessVBOM', 'VBAWarnings', 'ProtectedView', 'DisableAttachementsInPV', 'DisableInternetFilesInPV',
          'DisableUnsafeLocationsInPV', 'blockcontentexecutionfrominternet'),
     'May attempt to modify the VBA code (self-modification)':
-        ('VBProject', 'VBComponents', 'CodeModule', 'AddFromString'),
+        ('VBProject', 'VBComponents', 'CodeModule', 'AddFromString', 'Modules'),
     'May modify Excel 4 Macro formulas at runtime (XLM/XLF)':
         ('FORMULA.FILL',),
 }


### PR DESCRIPTION
I recently found [this question](https://stackoverflow.com/questions/54221055/excel-vba-import-module-from-text-file-without-requiring-trust-center) on Stack Overflow, it shows how to import a new code module in VBA using the `Modules` object.

Here's a simplified snippet that illustrates how it works:

```vba
    Dim ThisModule As Module
    Set ThisModule = ThisWorkbook.Modules.Add
    ThisModule.InsertFile ""C:\Users\(username)\Desktop\..."
```

I always thought you had to use `VBComponents.Import`, but turns out there is undocumented method as well. 