### PR TITLE
Relax pyparsing version specifier

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pyparsing>=2.1.0,<3
+pyparsing>=2.1.0,<4.0
 olefile>=0.46
 easygui
 colorclass

--- a/setup.py
+++ b/setup.py
@@ -320,7 +320,7 @@ def main():
         test_suite="tests",
         # scripts=scripts,
         install_requires=[
-            "pyparsing>=2.1.0,<3",  # changed from 2.2.0 to 2.1.0 for issue #481
+            "pyparsing>=2.1.0,<4.0",  # changed from 2.2.0 to 2.1.0 for issue #481
             "olefile>=0.46",
             "easygui",
             'colorclass',


### PR DESCRIPTION
Relax `pyparsing` version specifier to allow using `pyparsing` v3.

## Background

I want to use `oletools` with a library which specifically requires `pyparsing` v3+. More specifically, [this one](https://github.com/fhightower/ioc-finder/blob/main/requirements.txt#L3).

## v2-v3 Compatibility

v3 starts using `snake_case` API (e.g. `add_parse_action`) but it preserves `camelCase` API. So, as far as I checked, it's safe to use v3 with the current usage. (Ref. https://pyparsing-docs.readthedocs.io/en/latest/whats_new_in_3_0_0.html#api-changes)


