### PR TITLE
Remove imp import from xxxswf for python 3.12 compatability

### DIFF
--- a/oletools/thirdparty/xxxswf/xxxswf.py
+++ b/oletools/thirdparty/xxxswf/xxxswf.py
@@ -9,7 +9,6 @@
 
 import fnmatch 
 import hashlib
-import imp
 import math
 import os
 import re
@@ -43,7 +42,6 @@ def yaraScan(d):
     # test if yara module is installed
     # if not Yara can be downloaded from http://code.google.com/p/yara-project/
     try:
-        imp.find_module('yara')
         import yara 
     except ImportError:
         print('\t[ERROR] Yara module not installed - aborting scan')


### PR DESCRIPTION
The imp module is removed in 3.12 and causes an error when loading `xxxswf`. The recommended replacement is `importlib` but here the use of imp is actually redundant. When `yara` isn't found the `import yara` statement already throws an `ImportError` for 3.5 and earlier, and for 3.6 and later it throws a `ModuleNotFoundError` which is a subclass of `ImportError` and is caught by the same try catch.