### PR TITLE
rtfobj.py syntax error

### DIFF
--- a/oletools/rtfobj.py
+++ b/oletools/rtfobj.py
@@ -269,7 +269,7 @@ DELIMITER = b'[ \\t\\r\\n\\f\\v]'
 DELIMITERS_ZeroOrMore = b'[ \\t\\r\\n\\f\\v]*'
 BACKSLASH_BIN = b'\\\\bin'
 # According to my tests, Word accepts up to 250 digits (leading zeroes)
-DECIMAL_GROUP = b'(\d{1,250})'
+DECIMAL_GROUP = b'(\\d{1,250})'
 
 re_delims_bin_decimal = re.compile(DELIMITERS_ZeroOrMore + BACKSLASH_BIN
                                    + DECIMAL_GROUP + DELIMITER)


### PR DESCRIPTION
In python 3.12+ it is reporting the syntax error 

oletools/rtfobj.py:272
  /rpmbuild/BUILD/oletools-78b2d459a33df378a4f69ffc6c33313509cecfe4/oletools/rtfobj.py:272: SyntaxWarning: invalid escape sequence '\d'
    DECIMAL_GROUP = b'(\d{1,250})'