### PR TITLE
oleobj.py syntax error

### DIFF
--- a/oletools/oleobj.py
+++ b/oletools/oleobj.py
@@ -534,7 +534,7 @@ def sanitize_filename(filename, replacement='_',
     Might return empty string
     """
     basepath = os.path.basename(filename).strip()
-    sane_fname = re.sub(u'[^a-zA-Z0-9.\-_ ]', replacement, basepath)
+    sane_fname = re.sub(u'[^a-zA-Z0-9._ -]', replacement, basepath)
     sane_fname = str(sane_fname)    # py3: does nothing;   py2: unicode --> str
 
     while ".." in sane_fname:


### PR DESCRIPTION
In python 3.12+ this escaping is reported as syntax error. Moving the dash to the end of the regex avoids the need for escaping it.

oletools/oleobj.py:537
  /rpmbuild/BUILD/oletools-78b2d459a33df378a4f69ffc6c33313509cecfe4/oletools/oleobj.py:537: SyntaxWarning: invalid escape sequence '\-'
    sane_fname = re.sub(u'[^a-zA-Z0-9.\-_ ]', replacement, basepath)