### PR TITLE
Add the vba ppt sample to the `find_vba` list in the `test_macros` function.

### DIFF
--- a/tests/oleid/test_basic.py
+++ b/tests/oleid/test_basic.py
@@ -68,13 +68,14 @@ class TestOleIDBasic(unittest.TestCase):
                 self.assertEqual(value_dict['author'],
                                  b'\xb1\xe8\xb1\xe2\xc1\xa4;kijeong')
             elif join('olevba', 'sample_with_vba.ppt') in filename:
-                print('\nTODO: find reason for different results for sample_with_vba.ppt')
-                # on korean test machine, this is the result:
-                # self.assertEqual(value_dict['codepage'],
-                #                  '949: ANSI/OEM Korean (Unified Hangul Code)')
-                # self.assertEqual(value_dict['author'],
-                #                  b'\xb1\xe8 \xb1\xe2\xc1\xa4')
-                continue
+                self.assertEqual(value_dict['codepage'],
+                                 '949: ANSI/OEM Korean (Unified Hangul Code)',
+                                 'Unexpected result {0!r} for codepage of sample {1}'
+                                 .format(value_dict['codepage'], filename))
+                self.assertEqual(value_dict['author'],
+                                 b'\xb1\xe8 \xb1\xe2\xc1\xa4',
+                                 'Unexpected result {0!r} for author of sample {1}'
+                                 .format(value_dict['author'], filename))
             else:
                 self.assertEqual(value_dict['codepage'],
                                  '1252: ANSI Latin 1; Western European (Windows)',
@@ -121,8 +122,6 @@ class TestOleIDBasic(unittest.TestCase):
             join('oleform', 'oleform-PR314.docm'),
             join('basic', 'empty'),                   # WTF?
             join('basic', 'text'),
-        )
-        todo_inconsistent_results = (
             join('olevba', 'sample_with_vba.ppt'),
         )
         for filename, value_dict in self.oleids:
@@ -138,10 +137,6 @@ class TestOleIDBasic(unittest.TestCase):
             self.assertIn(value_dict['xlm'], ('Unknown', 'No'))
 
             # "macro detection" in text files leads to interesting results:
-            if filename in todo_inconsistent_results:
-                print("\nTODO: need to determine result inconsistency for sample {0}"
-                      .format(filename))
-                continue
             if filename in find_vba:                   # no macros!
                 self.assertEqual(value_dict['vba'], 'Yes')
             else:


### PR DESCRIPTION
This pull request is related to #859 and #723.
I made some additional adjustments to the changes from #859.
@christian-intra2net, it would be great if you could review it.

The file 'olevba/sample_with_vba.ppt' contains an actual VBA macro.

And in my opinion, the code page should not vary depending on the test machine.

I referred to the following parts:

- `olefile.py:OleFileIO.getproperties` function
  - `property_id: 1`, `value: 949`

- `codepages.py:get_codepage_name`, `CODEPAGE_NAME[949]`
