### PR TITLE
Prevent parsing of escape characters

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,7 +1,7 @@
 This license applies to the python-oletools package, apart from the thirdparty folder which contains third-party files 
 published with their own license.
 
-The python-oletools package is copyright (c) 2012-2024 Philippe Lagadec (http://www.decalage.info)
+The python-oletools package is copyright (c) 2012-2025 Philippe Lagadec (http://www.decalage.info)
 
 All rights reserved.
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Note: python-oletools is not related to OLETools published by BeCubed Software.
 News
 ----
 
+- **2025-05-21 v0.60.3**:
+    - olevba: fixed a security issue in the CLI display when ANSI escape codes are present (PR #873) 
 - **2024-07-02 v0.60.2**:
     - olevba: 
       - fixed a bug in open_slk (issue #797, PR #769)

--- a/oletools/README.html
+++ b/oletools/README.html
@@ -4,231 +4,61 @@
   <meta charset="utf-8" />
   <meta name="generator" content="pandoc" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
-  <title>-</title>
-  <style>
-    html {
-      line-height: 1.5;
-      font-family: Georgia, serif;
-      font-size: 20px;
-      color: #1a1a1a;
-      background-color: #fdfdfd;
-    }
-    body {
-      margin: 0 auto;
-      max-width: 36em;
-      padding-left: 50px;
-      padding-right: 50px;
-      padding-top: 50px;
-      padding-bottom: 50px;
-      hyphens: auto;
-      overflow-wrap: break-word;
-      text-rendering: optimizeLegibility;
-      font-kerning: normal;
-    }
-    @media (max-width: 600px) {
-      body {
-        font-size: 0.9em;
-        padding: 1em;
-      }
-      h1 {
-        font-size: 1.8em;
-      }
-    }
-    @media print {
-      body {
-        background-color: transparent;
-        color: black;
-        font-size: 12pt;
-      }
-      p, h2, h3 {
-        orphans: 3;
-        widows: 3;
-      }
-      h2, h3, h4 {
-        page-break-after: avoid;
-      }
-    }
-    p {
-      margin: 1em 0;
-    }
-    a {
-      color: #1a1a1a;
-    }
-    a:visited {
-      color: #1a1a1a;
-    }
-    img {
-      max-width: 100%;
-    }
-    h1, h2, h3, h4, h5, h6 {
-      margin-top: 1.4em;
-    }
-    h5, h6 {
-      font-size: 1em;
-      font-style: italic;
-    }
-    h6 {
-      font-weight: normal;
-    }
-    ol, ul {
-      padding-left: 1.7em;
-      margin-top: 1em;
-    }
-    li > ol, li > ul {
-      margin-top: 0;
-    }
-    blockquote {
-      margin: 1em 0 1em 1.7em;
-      padding-left: 1em;
-      border-left: 2px solid #e6e6e6;
-      color: #606060;
-    }
-    code {
-      font-family: Menlo, Monaco, 'Lucida Console', Consolas, monospace;
-      font-size: 85%;
-      margin: 0;
-    }
-    pre {
-      margin: 1em 0;
-      overflow: auto;
-    }
-    pre code {
-      padding: 0;
-      overflow: visible;
-      overflow-wrap: normal;
-    }
-    .sourceCode {
-     background-color: transparent;
-     overflow: visible;
-    }
-    hr {
-      background-color: #1a1a1a;
-      border: none;
-      height: 1px;
-      margin: 1em 0;
-    }
-    table {
-      margin: 1em 0;
-      border-collapse: collapse;
-      width: 100%;
-      overflow-x: auto;
-      display: block;
-      font-variant-numeric: lining-nums tabular-nums;
-    }
-    table caption {
-      margin-bottom: 0.75em;
-    }
-    tbody {
-      margin-top: 0.5em;
-      border-top: 1px solid #1a1a1a;
-      border-bottom: 1px solid #1a1a1a;
-    }
-    th {
-      border-top: 1px solid #1a1a1a;
-      padding: 0.25em 0.5em 0.25em 0.5em;
-    }
-    td {
-      padding: 0.125em 0.5em 0.25em 0.5em;
-    }
-    header {
-      margin-bottom: 4em;
-      text-align: center;
-    }
-    #TOC li {
-      list-style: none;
-    }
-    #TOC ul {
-      padding-left: 1.3em;
-    }
-    #TOC > ul {
-      padding-left: 0;
-    }
-    #TOC a:not(:hover) {
-      text-decoration: none;
-    }
-    code{white-space: pre-wrap;}
-    span.smallcaps{font-variant: small-caps;}
-    span.underline{text-decoration: underline;}
-    div.column{display: inline-block; vertical-align: top; width: 50%;}
-    div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
-    ul.task-list{list-style: none;}
-    .display.math{display: block; text-align: center; margin: 0.5rem auto;}
+  <title>Untitled</title>
+  <style type="text/css">
+      code{white-space: pre-wrap;}
+      span.smallcaps{font-variant: small-caps;}
+      span.underline{text-decoration: underline;}
+      div.column{display: inline-block; vertical-align: top; width: 50%;}
   </style>
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
 <h1 id="python-oletools">python-oletools</h1>
-<p><a href="https://pypi.org/project/oletools/"><img
-src="https://img.shields.io/pypi/v/oletools.svg" alt="PyPI" /></a> <a
-href="https://travis-ci.org/decalage2/oletools"><img
-src="https://travis-ci.org/decalage2/oletools.svg?branch=master"
-alt="Build Status" /></a> <a
-href="https://saythanks.io/to/decalage2"><img
-src="https://img.shields.io/badge/Say%20Thanks-!-1EAEDB.svg"
-alt="Say Thanks!" /></a></p>
-<p><a href="http://www.decalage.info/python/oletools">oletools</a> is a
-package of python tools to analyze <a
-href="http://en.wikipedia.org/wiki/Compound_File_Binary_Format">Microsoft
-OLE2 files</a> (also called Structured Storage, Compound File Binary
-Format or Compound Document File Format), such as Microsoft Office
-97-2003 documents, MSI files or Outlook messages, mainly for malware
-analysis, forensics and debugging. It is based on the <a
-href="http://www.decalage.info/olefile">olefile</a> parser.</p>
-<p>It also provides tools to analyze RTF files and files based on the <a
-href="https://en.wikipedia.org/wiki/Office_Open_XML">OpenXML format</a>
-(aka OOXML) such as MS Office 2007+ documents, XPS or MSIX files.</p>
-<p>For example, oletools can detect, extract and analyse VBA macros, OLE
-objects, Excel 4 macros (XLM) and DDE links.</p>
-<p>See <a
-href="http://www.decalage.info/python/oletools">http://www.decalage.info/python/oletools</a>
-for more info.</p>
-<p><strong>Quick links:</strong> <a
-href="http://www.decalage.info/python/oletools">Home page</a> - <a
-href="https://github.com/decalage2/oletools/wiki/Install">Download/Install</a>
-- <a href="https://github.com/decalage2/oletools/wiki">Documentation</a>
-- <a href="https://github.com/decalage2/oletools/issues">Report
-Issues/Suggestions/Questions</a> - <a
-href="http://decalage.info/contact">Contact the Author</a> - <a
-href="https://github.com/decalage2/oletools">Repository</a> - <a
-href="https://twitter.com/decalage2">Updates on Twitter</a> <a
-href="https://github.com/decalage2/oletools/blob/master/cheatsheet/oletools_cheatsheet.pdf">Cheatsheet</a></p>
-<p>Note: python-oletools is not related to OLETools published by BeCubed
-Software.</p>
+<p><a href="https://pypi.org/project/oletools/"><img src="https://img.shields.io/pypi/v/oletools.svg" alt="PyPI" /></a> <a href="https://travis-ci.org/decalage2/oletools"><img src="https://travis-ci.org/decalage2/oletools.svg?branch=master" alt="Build Status" /></a> <a href="https://saythanks.io/to/decalage2"><img src="https://img.shields.io/badge/Say%20Thanks-!-1EAEDB.svg" alt="Say Thanks!" /></a></p>
+<p><a href="http://www.decalage.info/python/oletools">oletools</a> is a package of python tools to analyze <a href="http://en.wikipedia.org/wiki/Compound_File_Binary_Format">Microsoft OLE2 files</a> (also called Structured Storage, Compound File Binary Format or Compound Document File Format), such as Microsoft Office 97-2003 documents, MSI files or Outlook messages, mainly for malware analysis, forensics and debugging. It is based on the <a href="http://www.decalage.info/olefile">olefile</a> parser.</p>
+<p>It also provides tools to analyze RTF files and files based on the <a href="https://en.wikipedia.org/wiki/Office_Open_XML">OpenXML format</a> (aka OOXML) such as MS Office 2007+ documents, XPS or MSIX files.</p>
+<p>For example, oletools can detect, extract and analyse VBA macros, OLE objects, Excel 4 macros (XLM) and DDE links.</p>
+<p>See <a href="http://www.decalage.info/python/oletools" class="uri">http://www.decalage.info/python/oletools</a> for more info.</p>
+<p><strong>Quick links:</strong> <a href="http://www.decalage.info/python/oletools">Home page</a> - <a href="https://github.com/decalage2/oletools/wiki/Install">Download/Install</a> - <a href="https://github.com/decalage2/oletools/wiki">Documentation</a> - <a href="https://github.com/decalage2/oletools/issues">Report Issues/Suggestions/Questions</a> - <a href="http://decalage.info/contact">Contact the Author</a> - <a href="https://github.com/decalage2/oletools">Repository</a> - <a href="https://twitter.com/decalage2">Updates on Twitter</a> <a href="https://github.com/decalage2/oletools/blob/master/cheatsheet/oletools_cheatsheet.pdf">Cheatsheet</a></p>
+<p>Note: python-oletools is not related to OLETools published by BeCubed Software.</p>
 <h2 id="news">News</h2>
 <ul>
+<li><strong>2025-05-21 v0.60.3</strong>:
+<ul>
+<li>olevba: fixed a security issue in the CLI display when ANSI escape codes are present (PR #873)</li>
+</ul></li>
 <li><strong>2024-07-02 v0.60.2</strong>:
 <ul>
 <li>olevba:
 <ul>
 <li>fixed a bug in open_slk (issue #797, PR #769)</li>
-<li>fixed a bug due to new PROJECTCOMPATVERSION record in dir stream (PR
-#723, issues #700, #701, #725, #791, #808, #811, #833)</li>
+<li>fixed a bug due to new PROJECTCOMPATVERSION record in dir stream (PR #723, issues #700, #701, #725, #791, #808, #811, #833)</li>
 </ul></li>
-<li>oleobj: fixed SyntaxError with Python 3.12 (PR #855), SyntaxWarning
-(PR #774)</li>
+<li>oleobj: fixed SyntaxError with Python 3.12 (PR #855), SyntaxWarning (PR #774)</li>
 <li>rtfobj: fixed SyntaxError with Python 3.12 (PR #854)</li>
 <li>clsid: added CLSIDs for MSI, Zed</li>
 <li>ftguess: added MSI, PNG and OneNote formats</li>
 <li>pyxswf: fixed python 3.12 compatibility (PR #841, issue #813)</li>
-<li>setup/requirements: allow pyparsing 3 to solve install issues (PR
-#812, issue #762)</li>
+<li>setup/requirements: allow pyparsing 3 to solve install issues (PR #812, issue #762)</li>
 </ul></li>
 <li><strong>2022-05-09 v0.60.1</strong>:
 <ul>
 <li>olevba:
 <ul>
 <li>fixed a bug when calling XLMMacroDeobfuscator (PR #737)</li>
-<li>removed keyword "sample" causing false positives</li>
+<li>removed keyword &quot;sample&quot; causing false positives</li>
 </ul></li>
 <li>oleid: fixed OleID init issue (issue #695, PR #696)</li>
 <li>oleobj:
 <ul>
 <li>added simple detection of CVE-2021-40444 initial stage</li>
 <li>added detection for customUI onLoad</li>
-<li>improved handling of incorrect filenames in OLE package (PR
-#451)</li>
+<li>improved handling of incorrect filenames in OLE package (PR #451)</li>
 </ul></li>
-<li>rtfobj: fixed code to find URLs in OLE2Link objects for Py3 (issue
-#692)</li>
+<li>rtfobj: fixed code to find URLs in OLE2Link objects for Py3 (issue #692)</li>
 <li>ftguess:
 <ul>
 <li>added PowerPoint and XPS formats (PR #716)</li>
@@ -239,8 +69,7 @@ Software.</p>
 </ul></li>
 <li><strong>2021-06-02 v0.60</strong>:
 <ul>
-<li>ftguess: new tool to identify file formats and containers (issue
-#680)</li>
+<li>ftguess: new tool to identify file formats and containers (issue #680)</li>
 <li>oleid: (issue #679)
 <ul>
 <li>each indicator now has a risk level</li>
@@ -250,232 +79,75 @@ Software.</p>
 </ul></li>
 <li>olevba:
 <ul>
-<li>when XLMMacroDeobfuscator is available, use it to extract and
-deobfuscate XLM macros</li>
+<li>when XLMMacroDeobfuscator is available, use it to extract and deobfuscate XLM macros</li>
 </ul></li>
 <li>rtfobj:
 <ul>
 <li>use ftguess to identify file type of OLE Package (issue #682)</li>
 <li>fixed bug in re_executable_extensions</li>
 </ul></li>
-<li>crypto: added PowerPoint transparent password '/01Hannes
-Ruescher/01' (issue #627)</li>
-<li>setup: XLMMacroDeobfuscator, xlrd2 and pyxlsb2 added as optional
-dependencies</li>
+<li>crypto: added PowerPoint transparent password '/01Hannes Ruescher/01' (issue #627)</li>
+<li>setup: XLMMacroDeobfuscator, xlrd2 and pyxlsb2 added as optional dependencies</li>
 </ul></li>
 </ul>
-<p>See the <a
-href="https://github.com/decalage2/oletools/wiki/Changelog">full
-changelog</a> for more information.</p>
+<p>See the <a href="https://github.com/decalage2/oletools/wiki/Changelog">full changelog</a> for more information.</p>
 <h2 id="tools">Tools:</h2>
-<h3 id="tools-to-analyze-malicious-documents">Tools to analyze malicious
-documents</h3>
+<h3 id="tools-to-analyze-malicious-documents">Tools to analyze malicious documents</h3>
 <ul>
-<li><a
-href="https://github.com/decalage2/oletools/wiki/oleid">oleid</a>: to
-analyze OLE files to detect specific characteristics usually found in
-malicious files.</li>
-<li><a
-href="https://github.com/decalage2/oletools/wiki/olevba">olevba</a>: to
-extract and analyze VBA Macro source code from MS Office documents (OLE
-and OpenXML).</li>
-<li><a
-href="https://github.com/decalage2/oletools/wiki/mraptor">MacroRaptor</a>:
-to detect malicious VBA Macros</li>
-<li><a
-href="https://github.com/decalage2/oletools/wiki/msodde">msodde</a>: to
-detect and extract DDE/DDEAUTO links from MS Office documents, RTF and
-CSV</li>
-<li><a
-href="https://github.com/decalage2/oletools/wiki/pyxswf">pyxswf</a>: to
-detect, extract and analyze Flash objects (SWF) that may be embedded in
-files such as MS Office documents (e.g. Word, Excel) and RTF, which is
-especially useful for malware analysis.</li>
-<li><a
-href="https://github.com/decalage2/oletools/wiki/oleobj">oleobj</a>: to
-extract embedded objects from OLE files.</li>
-<li><a
-href="https://github.com/decalage2/oletools/wiki/rtfobj">rtfobj</a>: to
-extract embedded objects from RTF files.</li>
+<li><a href="https://github.com/decalage2/oletools/wiki/oleid">oleid</a>: to analyze OLE files to detect specific characteristics usually found in malicious files.</li>
+<li><a href="https://github.com/decalage2/oletools/wiki/olevba">olevba</a>: to extract and analyze VBA Macro source code from MS Office documents (OLE and OpenXML).</li>
+<li><a href="https://github.com/decalage2/oletools/wiki/mraptor">MacroRaptor</a>: to detect malicious VBA Macros</li>
+<li><a href="https://github.com/decalage2/oletools/wiki/msodde">msodde</a>: to detect and extract DDE/DDEAUTO links from MS Office documents, RTF and CSV</li>
+<li><a href="https://github.com/decalage2/oletools/wiki/pyxswf">pyxswf</a>: to detect, extract and analyze Flash objects (SWF) that may be embedded in files such as MS Office documents (e.g. Word, Excel) and RTF, which is especially useful for malware analysis.</li>
+<li><a href="https://github.com/decalage2/oletools/wiki/oleobj">oleobj</a>: to extract embedded objects from OLE files.</li>
+<li><a href="https://github.com/decalage2/oletools/wiki/rtfobj">rtfobj</a>: to extract embedded objects from RTF files.</li>
 </ul>
-<h3 id="tools-to-analyze-the-structure-of-ole-files">Tools to analyze
-the structure of OLE files</h3>
+<h3 id="tools-to-analyze-the-structure-of-ole-files">Tools to analyze the structure of OLE files</h3>
 <ul>
-<li><a
-href="https://github.com/decalage2/oletools/wiki/olebrowse">olebrowse</a>:
-A simple GUI to browse OLE files (e.g. MS Word, Excel, Powerpoint
-documents), to view and extract individual data streams.</li>
-<li><a
-href="https://github.com/decalage2/oletools/wiki/olemeta">olemeta</a>:
-to extract all standard properties (metadata) from OLE files.</li>
-<li><a
-href="https://github.com/decalage2/oletools/wiki/oletimes">oletimes</a>:
-to extract creation and modification timestamps of all streams and
-storages.</li>
-<li><a
-href="https://github.com/decalage2/oletools/wiki/oledir">oledir</a>: to
-display all the directory entries of an OLE file, including free and
-orphaned entries.</li>
-<li><a
-href="https://github.com/decalage2/oletools/wiki/olemap">olemap</a>: to
-display a map of all the sectors in an OLE file.</li>
+<li><a href="https://github.com/decalage2/oletools/wiki/olebrowse">olebrowse</a>: A simple GUI to browse OLE files (e.g. MS Word, Excel, Powerpoint documents), to view and extract individual data streams.</li>
+<li><a href="https://github.com/decalage2/oletools/wiki/olemeta">olemeta</a>: to extract all standard properties (metadata) from OLE files.</li>
+<li><a href="https://github.com/decalage2/oletools/wiki/oletimes">oletimes</a>: to extract creation and modification timestamps of all streams and storages.</li>
+<li><a href="https://github.com/decalage2/oletools/wiki/oledir">oledir</a>: to display all the directory entries of an OLE file, including free and orphaned entries.</li>
+<li><a href="https://github.com/decalage2/oletools/wiki/olemap">olemap</a>: to display a map of all the sectors in an OLE file.</li>
 </ul>
 <h2 id="projects-using-oletools">Projects using oletools:</h2>
-<p>oletools are used by a number of projects and online malware analysis
-services, including <a
-href="https://github.com/IntegralDefense/ACE">ACE</a>, <a
-href="https://www.blackhat.com/eu-23/briefings/schedule/index.html#unmasking-apts-an-automated-approach-for-real-world-threat-attribution-35162">ADAPT</a>,
-<a href="https://sandbox.anlyz.io/">Anlyz.io</a>, <a
-href="https://www.cse-cst.gc.ca/en/assemblyline">AssemblyLine</a>, <a
-href="https://github.com/binref/refinery">Binary Refinery</a>, <a
-href="https://github.com/ctxis/CAPE">CAPE</a>, <a
-href="https://cincan.io">CinCan</a>, <a
-href="https://cortex.marketplace.pan.dev/marketplace/details/Oletools/">Cortex
-XSOAR (Palo Alto)</a>, <a
-href="https://github.com/cuckoosandbox/cuckoo">Cuckoo Sandbox</a>, <a
-href="https://github.com/cryps1s/DARKSURGEON">DARKSURGEON</a>, <a
-href="https://sandbox.deepviz.com/">Deepviz</a>, <a
-href="https://diario.elevenpaths.com/">DIARIO</a>, <a
-href="https://dridex.malwareconfig.com">dridex.malwareconfig.com</a>, <a
-href="https://github.com/ninoseki/eml_analyzer">EML Analyzer</a>, <a
-href="https://pub.expmon.com/">EXPMON</a>, <a
-href="https://certsocietegenerale.github.io/fame/">FAME</a>, <a
-href="https://github.com/fireeye/flare-vm">FLARE-VM</a>, <a
-href="https://www.glimps.fr/en/glimps-malware-2/">GLIMPS Malware</a>, <a
-href="https://www.hybrid-analysis.com/">Hybrid-analysis.com</a>, <a
-href="https://labs.inquest.net/">InQuest Labs</a>, <a
-href="https://github.com/certego/IntelOwl">IntelOwl</a>, <a
-href="https://www.document-analyzer.net/">Joe Sandbox</a>, <a
-href="https://github.com/lmco/laikaboss">Laika BOSS</a>, <a
-href="https://github.com/sbidy/MacroMilter">MacroMilter</a>, <a
-href="https://mailcow.email/">mailcow</a>, <a
-href="https://malshare.io">malshare.io</a>, <a
-href="https://github.com/Tigzy/malware-repo">malware-repo</a>, <a
-href="https://www.adlice.com/download/mrf/">Malware Repository Framework
-(MRF)</a>, <a href="https://bazaar.abuse.ch/">MalwareBazaar</a>, <a
-href="https://github.com/HeinleinSupport/olefy">olefy</a>, <a
-href="https://github.com/pandora-analysis/pandora">Pandora</a>, <a
-href="https://github.com/scVENUS/PeekabooAV">PeekabooAV</a>, <a
-href="https://github.com/bontchev/pcodedmp">pcodedmp</a>, <a
-href="https://github.com/CIRCL/PyCIRCLean">PyCIRCLean</a>, <a
-href="https://www.quarkslab.com/products-qflow/">QFlow</a>, <a
-href="https://github.com/CYB3RMX/Qu1cksc0pe">Qu1cksc0pe</a>, <a
-href="https://github.com/tylabs/quicksand">Tylabs QuickSand</a>, <a
-href="https://remnux.org/">REMnux</a>, <a
-href="https://github.com/countercept/snake">Snake</a>, <a
-href="https://app.sndbox.com">SNDBOX</a>, <a
-href="https://splunkbase.splunk.com/app/5365/">Splunk add-on for MS O365
-Email</a>, <a
-href="https://github.com/ldbo/SpuriousEmu">SpuriousEmu</a>, <a
-href="https://github.com/target/strelka">Strelka</a>, <a
-href="https://stoq.punchcyber.com/">stoQ</a>, <a
-href="https://docs.sublimesecurity.com/docs/enrichment-functions">Sublime
-Platform/MQL</a>, <a
-href="https://github.com/jstrosch/subparse">Subparse</a>, <a
-href="https://github.com/TheHive-Project/Cortex-Analyzers">TheHive/Cortex</a>,
-<a href="https://s.threatbook.com/">ThreatBoook</a>, <a
-href="https://tsurugi-linux.org/">TSUGURI Linux</a>, <a
-href="https://github.com/MalwareCantFly/Vba2Graph">Vba2Graph</a>, <a
-href="http://viper.li/">Viper</a>, <a
-href="https://github.com/decalage2/ViperMonkey">ViperMonkey</a>, <a
-href="https://yomi.yoroi.company">YOMI</a>, and probably <a
-href="https://www.virustotal.com">VirusTotal</a>, <a
-href="https://www.filescan.io">FileScan.IO</a>. And quite a few <a
-href="https://github.com/search?q=oletools&amp;type=Repositories">other
-projects on GitHub</a>. (Please <a
-href="(http://decalage.info/contact)">contact me</a> if you have or know
-a project using oletools)</p>
+<p>oletools are used by a number of projects and online malware analysis services, including <a href="https://github.com/IntegralDefense/ACE">ACE</a>, <a href="https://www.blackhat.com/eu-23/briefings/schedule/index.html#unmasking-apts-an-automated-approach-for-real-world-threat-attribution-35162">ADAPT</a>, <a href="https://sandbox.anlyz.io/">Anlyz.io</a>, <a href="https://www.cse-cst.gc.ca/en/assemblyline">AssemblyLine</a>, <a href="https://github.com/binref/refinery">Binary Refinery</a>, <a href="https://github.com/kevoreilly/CAPEv2">CAPE</a>, <a href="https://cincan.io">CinCan</a>, <a href="https://cortex.marketplace.pan.dev/marketplace/details/Oletools/">Cortex XSOAR (Palo Alto)</a>, <a href="https://github.com/cuckoosandbox/cuckoo">Cuckoo Sandbox</a>, <a href="https://github.com/cryps1s/DARKSURGEON">DARKSURGEON</a>, <a href="https://sandbox.deepviz.com/">Deepviz</a>, <a href="https://diario.elevenpaths.com/">DIARIO</a>, <a href="https://dridex.malwareconfig.com">dridex.malwareconfig.com</a>, <a href="https://github.com/ninoseki/eml_analyzer">EML Analyzer</a>, <a href="https://pub.expmon.com/">EXPMON</a>, <a href="https://certsocietegenerale.github.io/fame/">FAME</a>, <a href="https://github.com/fireeye/flare-vm">FLARE-VM</a>, <a href="https://www.glimps.fr/en/glimps-malware-2/">GLIMPS Malware</a>, <a href="https://www.hybrid-analysis.com/">Hybrid-analysis.com</a>, <a href="https://labs.inquest.net/">InQuest Labs</a>, <a href="https://github.com/certego/IntelOwl">IntelOwl</a>, <a href="https://www.document-analyzer.net/">Joe Sandbox</a>, <a href="https://github.com/lmco/laikaboss">Laika BOSS</a>, <a href="https://github.com/sbidy/MacroMilter">MacroMilter</a>, <a href="https://mailcow.email/">mailcow</a>, <a href="https://malshare.io">malshare.io</a>, <a href="https://github.com/Tigzy/malware-repo">malware-repo</a>, <a href="https://www.adlice.com/download/mrf/">Malware Repository Framework (MRF)</a>, <a href="https://bazaar.abuse.ch/">MalwareBazaar</a>, <a href="https://github.com/HeinleinSupport/olefy">olefy</a>, <a href="https://github.com/pandora-analysis/pandora">Pandora</a>, <a href="https://github.com/scVENUS/PeekabooAV">PeekabooAV</a>, <a href="https://github.com/bontchev/pcodedmp">pcodedmp</a>, <a href="https://github.com/CIRCL/PyCIRCLean">PyCIRCLean</a>, <a href="https://www.quarkslab.com/products-qflow/">QFlow</a>, <a href="https://github.com/CYB3RMX/Qu1cksc0pe">Qu1cksc0pe</a>, <a href="https://github.com/tylabs/quicksand">Tylabs QuickSand</a>, <a href="https://remnux.org/">REMnux</a>, <a href="https://github.com/countercept/snake">Snake</a>, <a href="https://app.sndbox.com">SNDBOX</a>, <a href="https://splunkbase.splunk.com/app/5365/">Splunk add-on for MS O365 Email</a>, <a href="https://github.com/ldbo/SpuriousEmu">SpuriousEmu</a>, <a href="https://github.com/target/strelka">Strelka</a>, <a href="https://stoq.punchcyber.com/">stoQ</a>, <a href="https://docs.sublimesecurity.com/docs/enrichment-functions">Sublime Platform/MQL</a>, <a href="https://github.com/jstrosch/subparse">Subparse</a>, <a href="https://github.com/TheHive-Project/Cortex-Analyzers">TheHive/Cortex</a>, <a href="https://s.threatbook.com/">ThreatBoook</a>, <a href="https://tsurugi-linux.org/">TSUGURI Linux</a>, <a href="https://github.com/MalwareCantFly/Vba2Graph">Vba2Graph</a>, <a href="http://viper.li/">Viper</a>, <a href="https://github.com/decalage2/ViperMonkey">ViperMonkey</a>, <a href="https://yomi.yoroi.company">YOMI</a>, and probably <a href="https://www.virustotal.com">VirusTotal</a>, <a href="https://www.filescan.io">FileScan.IO</a>. And quite a few <a href="https://github.com/search?q=oletools&amp;type=Repositories">other projects on GitHub</a>. (Please <a href="(http://decalage.info/contact)">contact me</a> if you have or know a project using oletools)</p>
 <h2 id="download-and-install">Download and Install:</h2>
-<p>The recommended way to download and install/update the <strong>latest
-stable release</strong> of oletools is to use <a
-href="https://pip.pypa.io/en/stable/installing/">pip</a>:</p>
+<p>The recommended way to download and install/update the <strong>latest stable release</strong> of oletools is to use <a href="https://pip.pypa.io/en/stable/installing/">pip</a>:</p>
 <ul>
-<li>On Linux/Mac:
-<code>sudo -H pip install -U oletools[full]</code></li>
+<li>On Linux/Mac: <code>sudo -H pip install -U oletools[full]</code></li>
 <li>On Windows: <code>pip install -U oletools[full]</code></li>
 </ul>
-<p>This should automatically create command-line scripts to run each
-tool from any directory: <code>olevba</code>, <code>mraptor</code>,
-<code>rtfobj</code>, etc.</p>
-<p>The keyword <code>[full]</code> means that all optional dependencies
-will be installed, such as XLMMacroDeobfuscator. If you prefer a lighter
-version without optional dependencies, just remove <code>[full]</code>
-from the command line.</p>
+<p>This should automatically create command-line scripts to run each tool from any directory: <code>olevba</code>, <code>mraptor</code>, <code>rtfobj</code>, etc.</p>
+<p>The keyword <code>[full]</code> means that all optional dependencies will be installed, such as XLMMacroDeobfuscator. If you prefer a lighter version without optional dependencies, just remove <code>[full]</code> from the command line.</p>
 <p>To get the <strong>latest development version</strong> instead:</p>
 <ul>
-<li>On Linux/Mac:
-<code>sudo -H pip install -U https://github.com/decalage2/oletools/archive/master.zip</code></li>
-<li>On Windows:
-<code>pip install -U https://github.com/decalage2/oletools/archive/master.zip</code></li>
+<li>On Linux/Mac: <code>sudo -H pip install -U https://github.com/decalage2/oletools/archive/master.zip</code></li>
+<li>On Windows: <code>pip install -U https://github.com/decalage2/oletools/archive/master.zip</code></li>
 </ul>
-<p>See the <a
-href="https://github.com/decalage2/oletools/wiki/Install">documentation</a>
-for other installation options.</p>
+<p>See the <a href="https://github.com/decalage2/oletools/wiki/Install">documentation</a> for other installation options.</p>
 <h2 id="documentation">Documentation:</h2>
-<p>The latest version of the documentation can be found <a
-href="https://github.com/decalage2/oletools/wiki">online</a>, otherwise
-a copy is provided in the doc subfolder of the package.</p>
-<h2 id="how-to-suggest-improvements-report-issues-or-contribute">How to
-Suggest Improvements, Report Issues or Contribute:</h2>
-<p>This is a personal open-source project, developed on my spare time.
-Any contribution, suggestion, feedback or bug report is welcome.</p>
-<p>To suggest improvements, report a bug or any issue, please use the <a
-href="https://github.com/decalage2/oletools/issues">issue reporting
-page</a>, providing all the information and files to reproduce the
-problem.</p>
-<p>You may also <a href="http://decalage.info/contact">contact the
-author</a> directly to provide feedback.</p>
-<p>The code is available in <a
-href="https://github.com/decalage2/oletools">a GitHub repository</a>.
-You may use it to submit enhancements using forks and pull requests.</p>
+<p>The latest version of the documentation can be found <a href="https://github.com/decalage2/oletools/wiki">online</a>, otherwise a copy is provided in the doc subfolder of the package.</p>
+<h2 id="how-to-suggest-improvements-report-issues-or-contribute">How to Suggest Improvements, Report Issues or Contribute:</h2>
+<p>This is a personal open-source project, developed on my spare time. Any contribution, suggestion, feedback or bug report is welcome.</p>
+<p>To suggest improvements, report a bug or any issue, please use the <a href="https://github.com/decalage2/oletools/issues">issue reporting page</a>, providing all the information and files to reproduce the problem.</p>
+<p>You may also <a href="http://decalage.info/contact">contact the author</a> directly to provide feedback.</p>
+<p>The code is available in <a href="https://github.com/decalage2/oletools">a GitHub repository</a>. You may use it to submit enhancements using forks and pull requests.</p>
 <h2 id="license">License</h2>
-<p>This license applies to the python-oletools package, apart from the
-thirdparty folder which contains third-party files published with their
-own license.</p>
-<p>The python-oletools package is copyright (c) 2012-2024 Philippe
-Lagadec (http://www.decalage.info)</p>
+<p>This license applies to the python-oletools package, apart from the thirdparty folder which contains third-party files published with their own license.</p>
+<p>The python-oletools package is copyright (c) 2012-2024 Philippe Lagadec (http://www.decalage.info)</p>
 <p>All rights reserved.</p>
-<p>Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:</p>
+<p>Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:</p>
 <ul>
-<li>Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.</li>
-<li>Redistributions in binary form must reproduce the above copyright
-notice, this list of conditions and the following disclaimer in the
-documentation and/or other materials provided with the
-distribution.</li>
+<li>Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.</li>
+<li>Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.</li>
 </ul>
-<p>THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
-TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</p>
+<p>THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&quot; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</p>
 <hr />
-<p>olevba contains modified source code from the officeparser project,
-published under the following MIT License (MIT):</p>
+<p>olevba contains modified source code from the officeparser project, published under the following MIT License (MIT):</p>
 <p>officeparser is copyright (c) 2014 John William Davison</p>
-<p>Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:</p>
-<p>The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.</p>
-<p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</p>
+<p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:</p>
+<p>The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.</p>
+<p>THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</p>
 </body>
 </html>

--- a/oletools/README.rst
+++ b/oletools/README.rst
@@ -38,6 +38,11 @@ Software.
 News
 ----
 
+-  **2025-05-21 v0.60.3**:
+
+   -  olevba: fixed a security issue in the CLI display when ANSI escape
+      codes are present (PR #873)
+
 -  **2024-07-02 v0.60.2**:
 
    -  olevba:
@@ -162,7 +167,7 @@ services, including `ACE <https://github.com/IntegralDefense/ACE>`__,
 `Anlyz.io <https://sandbox.anlyz.io/>`__,
 `AssemblyLine <https://www.cse-cst.gc.ca/en/assemblyline>`__, `Binary
 Refinery <https://github.com/binref/refinery>`__,
-`CAPE <https://github.com/ctxis/CAPE>`__,
+`CAPE <https://github.com/kevoreilly/CAPEv2>`__,
 `CinCan <https://cincan.io>`__, `Cortex XSOAR (Palo
 Alto) <https://cortex.marketplace.pan.dev/marketplace/details/Oletools/>`__,
 `Cuckoo Sandbox <https://github.com/cuckoosandbox/cuckoo>`__,

--- a/oletools/doc/Contribute.html
+++ b/oletools/doc/Contribute.html
@@ -4,182 +4,30 @@
   <meta charset="utf-8" />
   <meta name="generator" content="pandoc" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
-  <title>-</title>
-  <style>
-    html {
-      line-height: 1.5;
-      font-family: Georgia, serif;
-      font-size: 20px;
-      color: #1a1a1a;
-      background-color: #fdfdfd;
-    }
-    body {
-      margin: 0 auto;
-      max-width: 36em;
-      padding-left: 50px;
-      padding-right: 50px;
-      padding-top: 50px;
-      padding-bottom: 50px;
-      hyphens: auto;
-      overflow-wrap: break-word;
-      text-rendering: optimizeLegibility;
-      font-kerning: normal;
-    }
-    @media (max-width: 600px) {
-      body {
-        font-size: 0.9em;
-        padding: 1em;
-      }
-      h1 {
-        font-size: 1.8em;
-      }
-    }
-    @media print {
-      body {
-        background-color: transparent;
-        color: black;
-        font-size: 12pt;
-      }
-      p, h2, h3 {
-        orphans: 3;
-        widows: 3;
-      }
-      h2, h3, h4 {
-        page-break-after: avoid;
-      }
-    }
-    p {
-      margin: 1em 0;
-    }
-    a {
-      color: #1a1a1a;
-    }
-    a:visited {
-      color: #1a1a1a;
-    }
-    img {
-      max-width: 100%;
-    }
-    h1, h2, h3, h4, h5, h6 {
-      margin-top: 1.4em;
-    }
-    h5, h6 {
-      font-size: 1em;
-      font-style: italic;
-    }
-    h6 {
-      font-weight: normal;
-    }
-    ol, ul {
-      padding-left: 1.7em;
-      margin-top: 1em;
-    }
-    li > ol, li > ul {
-      margin-top: 0;
-    }
-    blockquote {
-      margin: 1em 0 1em 1.7em;
-      padding-left: 1em;
-      border-left: 2px solid #e6e6e6;
-      color: #606060;
-    }
-    code {
-      font-family: Menlo, Monaco, 'Lucida Console', Consolas, monospace;
-      font-size: 85%;
-      margin: 0;
-    }
-    pre {
-      margin: 1em 0;
-      overflow: auto;
-    }
-    pre code {
-      padding: 0;
-      overflow: visible;
-      overflow-wrap: normal;
-    }
-    .sourceCode {
-     background-color: transparent;
-     overflow: visible;
-    }
-    hr {
-      background-color: #1a1a1a;
-      border: none;
-      height: 1px;
-      margin: 1em 0;
-    }
-    table {
-      margin: 1em 0;
-      border-collapse: collapse;
-      width: 100%;
-      overflow-x: auto;
-      display: block;
-      font-variant-numeric: lining-nums tabular-nums;
-    }
-    table caption {
-      margin-bottom: 0.75em;
-    }
-    tbody {
-      margin-top: 0.5em;
-      border-top: 1px solid #1a1a1a;
-      border-bottom: 1px solid #1a1a1a;
-    }
-    th {
-      border-top: 1px solid #1a1a1a;
-      padding: 0.25em 0.5em 0.25em 0.5em;
-    }
-    td {
-      padding: 0.125em 0.5em 0.25em 0.5em;
-    }
-    header {
-      margin-bottom: 4em;
-      text-align: center;
-    }
-    #TOC li {
-      list-style: none;
-    }
-    #TOC ul {
-      padding-left: 1.3em;
-    }
-    #TOC > ul {
-      padding-left: 0;
-    }
-    #TOC a:not(:hover) {
-      text-decoration: none;
-    }
-    code{white-space: pre-wrap;}
-    span.smallcaps{font-variant: small-caps;}
-    span.underline{text-decoration: underline;}
-    div.column{display: inline-block; vertical-align: top; width: 50%;}
-    div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
-    ul.task-list{list-style: none;}
-    .display.math{display: block; text-align: center; margin: 0.5rem auto;}
+  <title>Untitled</title>
+  <style type="text/css">
+      code{white-space: pre-wrap;}
+      span.smallcaps{font-variant: small-caps;}
+      span.underline{text-decoration: underline;}
+      div.column{display: inline-block; vertical-align: top; width: 50%;}
   </style>
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
-<h1 id="how-to-suggest-improvements-report-issues-or-contribute">How to
-Suggest Improvements, Report Issues or Contribute</h1>
-<p>This is a personal open-source project, developed on my spare time.
-Any contribution, suggestion, feedback or bug report is welcome.</p>
-<p>To <strong>suggest improvements, report a bug or any issue</strong>,
-please use the <a
-href="https://github.com/decalage2/oletools/issues">issue reporting
-page</a>, and provide all the information and files to reproduce the
-problem.</p>
-<p>You may also <a href="http://decalage.info/contact">contact the
-author</a> directly to <strong>send feedback</strong>.</p>
-<p>The code is available in <a
-href="https://github.com/decalage2/oletools">a repository on GitHub</a>.
-You may use it to <strong>submit enhancements</strong> using forks and
-pull requests.</p>
+<h1 id="how-to-suggest-improvements-report-issues-or-contribute">How to Suggest Improvements, Report Issues or Contribute</h1>
+<p>This is a personal open-source project, developed on my spare time. Any contribution, suggestion, feedback or bug report is welcome.</p>
+<p>To <strong>suggest improvements, report a bug or any issue</strong>, please use the <a href="https://github.com/decalage2/oletools/issues">issue reporting page</a>, and provide all the information and files to reproduce the problem.</p>
+<p>You may also <a href="http://decalage.info/contact">contact the author</a> directly to <strong>send feedback</strong>.</p>
+<p>The code is available in <a href="https://github.com/decalage2/oletools">a repository on GitHub</a>. You may use it to <strong>submit enhancements</strong> using forks and pull requests.</p>
 <hr />
-<h2 id="python-oletools-documentation">python-oletools
-documentation</h2>
+<h2 id="python-oletools-documentation">python-oletools documentation</h2>
 <ul>
 <li><a href="Home.html">Home</a></li>
 <li><a href="License.html">License</a></li>
 <li><a href="Install.html">Install</a></li>
-<li><a href="Contribute.html">Contribute</a>, Suggest Improvements or
-Report Issues</li>
+<li><a href="Contribute.html">Contribute</a>, Suggest Improvements or Report Issues</li>
 <li>Tools:
 <ul>
 <li><a href="mraptor.html">mraptor</a></li>

--- a/oletools/doc/Home.html
+++ b/oletools/doc/Home.html
@@ -4,240 +4,53 @@
   <meta charset="utf-8" />
   <meta name="generator" content="pandoc" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
-  <title>-</title>
-  <style>
-    html {
-      line-height: 1.5;
-      font-family: Georgia, serif;
-      font-size: 20px;
-      color: #1a1a1a;
-      background-color: #fdfdfd;
-    }
-    body {
-      margin: 0 auto;
-      max-width: 36em;
-      padding-left: 50px;
-      padding-right: 50px;
-      padding-top: 50px;
-      padding-bottom: 50px;
-      hyphens: auto;
-      overflow-wrap: break-word;
-      text-rendering: optimizeLegibility;
-      font-kerning: normal;
-    }
-    @media (max-width: 600px) {
-      body {
-        font-size: 0.9em;
-        padding: 1em;
-      }
-      h1 {
-        font-size: 1.8em;
-      }
-    }
-    @media print {
-      body {
-        background-color: transparent;
-        color: black;
-        font-size: 12pt;
-      }
-      p, h2, h3 {
-        orphans: 3;
-        widows: 3;
-      }
-      h2, h3, h4 {
-        page-break-after: avoid;
-      }
-    }
-    p {
-      margin: 1em 0;
-    }
-    a {
-      color: #1a1a1a;
-    }
-    a:visited {
-      color: #1a1a1a;
-    }
-    img {
-      max-width: 100%;
-    }
-    h1, h2, h3, h4, h5, h6 {
-      margin-top: 1.4em;
-    }
-    h5, h6 {
-      font-size: 1em;
-      font-style: italic;
-    }
-    h6 {
-      font-weight: normal;
-    }
-    ol, ul {
-      padding-left: 1.7em;
-      margin-top: 1em;
-    }
-    li > ol, li > ul {
-      margin-top: 0;
-    }
-    blockquote {
-      margin: 1em 0 1em 1.7em;
-      padding-left: 1em;
-      border-left: 2px solid #e6e6e6;
-      color: #606060;
-    }
-    code {
-      font-family: Menlo, Monaco, 'Lucida Console', Consolas, monospace;
-      font-size: 85%;
-      margin: 0;
-    }
-    pre {
-      margin: 1em 0;
-      overflow: auto;
-    }
-    pre code {
-      padding: 0;
-      overflow: visible;
-      overflow-wrap: normal;
-    }
-    .sourceCode {
-     background-color: transparent;
-     overflow: visible;
-    }
-    hr {
-      background-color: #1a1a1a;
-      border: none;
-      height: 1px;
-      margin: 1em 0;
-    }
-    table {
-      margin: 1em 0;
-      border-collapse: collapse;
-      width: 100%;
-      overflow-x: auto;
-      display: block;
-      font-variant-numeric: lining-nums tabular-nums;
-    }
-    table caption {
-      margin-bottom: 0.75em;
-    }
-    tbody {
-      margin-top: 0.5em;
-      border-top: 1px solid #1a1a1a;
-      border-bottom: 1px solid #1a1a1a;
-    }
-    th {
-      border-top: 1px solid #1a1a1a;
-      padding: 0.25em 0.5em 0.25em 0.5em;
-    }
-    td {
-      padding: 0.125em 0.5em 0.25em 0.5em;
-    }
-    header {
-      margin-bottom: 4em;
-      text-align: center;
-    }
-    #TOC li {
-      list-style: none;
-    }
-    #TOC ul {
-      padding-left: 1.3em;
-    }
-    #TOC > ul {
-      padding-left: 0;
-    }
-    #TOC a:not(:hover) {
-      text-decoration: none;
-    }
-    code{white-space: pre-wrap;}
-    span.smallcaps{font-variant: small-caps;}
-    span.underline{text-decoration: underline;}
-    div.column{display: inline-block; vertical-align: top; width: 50%;}
-    div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
-    ul.task-list{list-style: none;}
-    .display.math{display: block; text-align: center; margin: 0.5rem auto;}
+  <title>Untitled</title>
+  <style type="text/css">
+      code{white-space: pre-wrap;}
+      span.smallcaps{font-variant: small-caps;}
+      span.underline{text-decoration: underline;}
+      div.column{display: inline-block; vertical-align: top; width: 50%;}
   </style>
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
-<h1 id="python-oletools-documentation">python-oletools
-documentation</h1>
-<p>This is the home page of the documentation for python-oletools. The
-latest version can be found <a
-href="https://github.com/decalage2/oletools/wiki">online</a>, otherwise
-a copy is provided in the doc subfolder of the package.</p>
-<p><a href="http://www.decalage.info/python/oletools">oletools</a> is a
-package of python tools to analyze <a
-href="http://en.wikipedia.org/wiki/Compound_File_Binary_Format">Microsoft
-OLE2 files</a> (also called Structured Storage, Compound File Binary
-Format or Compound Document File Format), such as Microsoft Office
-97-2003 documents, MSI files or Outlook messages, mainly for malware
-analysis, forensics and debugging. It is based on the <a
-href="http://www.decalage.info/olefile">olefile</a> parser.</p>
-<p>It also provides tools to analyze RTF files and files based on the <a
-href="https://en.wikipedia.org/wiki/Office_Open_XML">OpenXML format</a>
-(aka OOXML) such as MS Office 2007+ documents, XPS or MSIX files.</p>
-<p>For example, oletools can detect, extract and analyse VBA macros, OLE
-objects, Excel 4 macros (XLM) and DDE links.</p>
-<p>See <a
-href="http://www.decalage.info/python/oletools">http://www.decalage.info/python/oletools</a>
-for more info.</p>
-<p><strong>Quick links:</strong> <a
-href="http://www.decalage.info/python/oletools">Home page</a> - <a
-href="https://github.com/decalage2/oletools/wiki/Install">Download/Install</a>
-- <a href="https://github.com/decalage2/oletools/wiki">Documentation</a>
-- <a href="https://github.com/decalage2/oletools/issues">Report
-Issues/Suggestions/Questions</a> - <a
-href="http://decalage.info/contact">Contact the Author</a> - <a
-href="https://github.com/decalage2/oletools">Repository</a> - <a
-href="https://twitter.com/decalage2">Updates on Twitter</a></p>
-<p>Note: python-oletools is not related to OLETools published by BeCubed
-Software.</p>
+<h1 id="python-oletools-documentation">python-oletools documentation</h1>
+<p>This is the home page of the documentation for python-oletools. The latest version can be found <a href="https://github.com/decalage2/oletools/wiki">online</a>, otherwise a copy is provided in the doc subfolder of the package.</p>
+<p><a href="http://www.decalage.info/python/oletools">oletools</a> is a package of python tools to analyze <a href="http://en.wikipedia.org/wiki/Compound_File_Binary_Format">Microsoft OLE2 files</a> (also called Structured Storage, Compound File Binary Format or Compound Document File Format), such as Microsoft Office 97-2003 documents, MSI files or Outlook messages, mainly for malware analysis, forensics and debugging. It is based on the <a href="http://www.decalage.info/olefile">olefile</a> parser.</p>
+<p>It also provides tools to analyze RTF files and files based on the <a href="https://en.wikipedia.org/wiki/Office_Open_XML">OpenXML format</a> (aka OOXML) such as MS Office 2007+ documents, XPS or MSIX files.</p>
+<p>For example, oletools can detect, extract and analyse VBA macros, OLE objects, Excel 4 macros (XLM) and DDE links.</p>
+<p>See <a href="http://www.decalage.info/python/oletools" class="uri">http://www.decalage.info/python/oletools</a> for more info.</p>
+<p><strong>Quick links:</strong> <a href="http://www.decalage.info/python/oletools">Home page</a> - <a href="https://github.com/decalage2/oletools/wiki/Install">Download/Install</a> - <a href="https://github.com/decalage2/oletools/wiki">Documentation</a> - <a href="https://github.com/decalage2/oletools/issues">Report Issues/Suggestions/Questions</a> - <a href="http://decalage.info/contact">Contact the Author</a> - <a href="https://github.com/decalage2/oletools">Repository</a> - <a href="https://twitter.com/decalage2">Updates on Twitter</a></p>
+<p>Note: python-oletools is not related to OLETools published by BeCubed Software.</p>
 <h2 id="tools-in-python-oletools">Tools in python-oletools:</h2>
-<h3 id="tools-to-analyze-malicious-documents">Tools to analyze malicious
-documents</h3>
+<h3 id="tools-to-analyze-malicious-documents">Tools to analyze malicious documents</h3>
 <ul>
-<li><strong><a href="oleid.html">oleid</a></strong>: to analyze OLE
-files to detect specific characteristics usually found in malicious
-files.</li>
-<li><strong><a href="olevba.html">olevba</a></strong>: to extract and
-analyze VBA Macro source code from MS Office documents (OLE and
-OpenXML).</li>
-<li><strong><a href="mraptor.html">mraptor</a></strong>: to detect
-malicious VBA Macros</li>
-<li><strong><a href="msodde.html">msodde</a></strong>: to detect and
-extract DDE/DDEAUTO links from MS Office documents, RTF and CSV</li>
-<li><strong><a href="pyxswf.html">pyxswf</a></strong>: to detect,
-extract and analyze Flash objects (SWF) that may be embedded in files
-such as MS Office documents (e.g. Word, Excel) and RTF, which is
-especially useful for malware analysis.</li>
-<li><strong><a href="oleobj.html">oleobj</a></strong>: to extract
-embedded objects from OLE files.</li>
-<li><strong><a href="rtfobj.html">rtfobj</a></strong>: to extract
-embedded objects from RTF files.</li>
+<li><strong><a href="oleid.html">oleid</a></strong>: to analyze OLE files to detect specific characteristics usually found in malicious files.</li>
+<li><strong><a href="olevba.html">olevba</a></strong>: to extract and analyze VBA Macro source code from MS Office documents (OLE and OpenXML).</li>
+<li><strong><a href="mraptor.html">mraptor</a></strong>: to detect malicious VBA Macros</li>
+<li><strong><a href="msodde.html">msodde</a></strong>: to detect and extract DDE/DDEAUTO links from MS Office documents, RTF and CSV</li>
+<li><strong><a href="pyxswf.html">pyxswf</a></strong>: to detect, extract and analyze Flash objects (SWF) that may be embedded in files such as MS Office documents (e.g. Word, Excel) and RTF, which is especially useful for malware analysis.</li>
+<li><strong><a href="oleobj.html">oleobj</a></strong>: to extract embedded objects from OLE files.</li>
+<li><strong><a href="rtfobj.html">rtfobj</a></strong>: to extract embedded objects from RTF files.</li>
 </ul>
-<h3 id="tools-to-analyze-the-structure-of-ole-files">Tools to analyze
-the structure of OLE files</h3>
+<h3 id="tools-to-analyze-the-structure-of-ole-files">Tools to analyze the structure of OLE files</h3>
 <ul>
-<li><strong><a href="olebrowse.html">olebrowse</a></strong>: A simple
-GUI to browse OLE files (e.g. MS Word, Excel, Powerpoint documents), to
-view and extract individual data streams.</li>
-<li><strong><a href="olemeta.html">olemeta</a></strong>: to extract all
-standard properties (metadata) from OLE files.</li>
-<li><strong><a href="oletimes.html">oletimes</a></strong>: to extract
-creation and modification timestamps of all streams and storages.</li>
-<li><strong><a href="oledir.html">oledir</a></strong>: to display all
-the directory entries of an OLE file, including free and orphaned
-entries.</li>
-<li><strong><a href="olemap.html">olemap</a></strong>: to display a map
-of all the sectors in an OLE file.</li>
+<li><strong><a href="olebrowse.html">olebrowse</a></strong>: A simple GUI to browse OLE files (e.g. MS Word, Excel, Powerpoint documents), to view and extract individual data streams.</li>
+<li><strong><a href="olemeta.html">olemeta</a></strong>: to extract all standard properties (metadata) from OLE files.</li>
+<li><strong><a href="oletimes.html">oletimes</a></strong>: to extract creation and modification timestamps of all streams and storages.</li>
+<li><strong><a href="oledir.html">oledir</a></strong>: to display all the directory entries of an OLE file, including free and orphaned entries.</li>
+<li><strong><a href="olemap.html">olemap</a></strong>: to display a map of all the sectors in an OLE file.</li>
 <li>and a few others (coming soon)</li>
 </ul>
 <hr />
-<h2 id="python-oletools-documentation-1">python-oletools
-documentation</h2>
+<h2 id="python-oletools-documentation-1">python-oletools documentation</h2>
 <ul>
 <li><a href="Home.html">Home</a></li>
 <li><a href="License.html">License</a></li>
 <li><a href="Install.html">Install</a></li>
-<li><a href="Contribute.html">Contribute</a>, Suggest Improvements or
-Report Issues</li>
+<li><a href="Contribute.html">Contribute</a>, Suggest Improvements or Report Issues</li>
 <li>Tools:
 <ul>
 <li><a href="mraptor.html">mraptor</a></li>

--- a/oletools/doc/Install.html
+++ b/oletools/doc/Install.html
@@ -4,267 +4,75 @@
   <meta charset="utf-8" />
   <meta name="generator" content="pandoc" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
-  <title>-</title>
-  <style>
-    html {
-      line-height: 1.5;
-      font-family: Georgia, serif;
-      font-size: 20px;
-      color: #1a1a1a;
-      background-color: #fdfdfd;
-    }
-    body {
-      margin: 0 auto;
-      max-width: 36em;
-      padding-left: 50px;
-      padding-right: 50px;
-      padding-top: 50px;
-      padding-bottom: 50px;
-      hyphens: auto;
-      overflow-wrap: break-word;
-      text-rendering: optimizeLegibility;
-      font-kerning: normal;
-    }
-    @media (max-width: 600px) {
-      body {
-        font-size: 0.9em;
-        padding: 1em;
-      }
-      h1 {
-        font-size: 1.8em;
-      }
-    }
-    @media print {
-      body {
-        background-color: transparent;
-        color: black;
-        font-size: 12pt;
-      }
-      p, h2, h3 {
-        orphans: 3;
-        widows: 3;
-      }
-      h2, h3, h4 {
-        page-break-after: avoid;
-      }
-    }
-    p {
-      margin: 1em 0;
-    }
-    a {
-      color: #1a1a1a;
-    }
-    a:visited {
-      color: #1a1a1a;
-    }
-    img {
-      max-width: 100%;
-    }
-    h1, h2, h3, h4, h5, h6 {
-      margin-top: 1.4em;
-    }
-    h5, h6 {
-      font-size: 1em;
-      font-style: italic;
-    }
-    h6 {
-      font-weight: normal;
-    }
-    ol, ul {
-      padding-left: 1.7em;
-      margin-top: 1em;
-    }
-    li > ol, li > ul {
-      margin-top: 0;
-    }
-    blockquote {
-      margin: 1em 0 1em 1.7em;
-      padding-left: 1em;
-      border-left: 2px solid #e6e6e6;
-      color: #606060;
-    }
-    code {
-      font-family: Menlo, Monaco, 'Lucida Console', Consolas, monospace;
-      font-size: 85%;
-      margin: 0;
-    }
-    pre {
-      margin: 1em 0;
-      overflow: auto;
-    }
-    pre code {
-      padding: 0;
-      overflow: visible;
-      overflow-wrap: normal;
-    }
-    .sourceCode {
-     background-color: transparent;
-     overflow: visible;
-    }
-    hr {
-      background-color: #1a1a1a;
-      border: none;
-      height: 1px;
-      margin: 1em 0;
-    }
-    table {
-      margin: 1em 0;
-      border-collapse: collapse;
-      width: 100%;
-      overflow-x: auto;
-      display: block;
-      font-variant-numeric: lining-nums tabular-nums;
-    }
-    table caption {
-      margin-bottom: 0.75em;
-    }
-    tbody {
-      margin-top: 0.5em;
-      border-top: 1px solid #1a1a1a;
-      border-bottom: 1px solid #1a1a1a;
-    }
-    th {
-      border-top: 1px solid #1a1a1a;
-      padding: 0.25em 0.5em 0.25em 0.5em;
-    }
-    td {
-      padding: 0.125em 0.5em 0.25em 0.5em;
-    }
-    header {
-      margin-bottom: 4em;
-      text-align: center;
-    }
-    #TOC li {
-      list-style: none;
-    }
-    #TOC ul {
-      padding-left: 1.3em;
-    }
-    #TOC > ul {
-      padding-left: 0;
-    }
-    #TOC a:not(:hover) {
-      text-decoration: none;
-    }
-    code{white-space: pre-wrap;}
-    span.smallcaps{font-variant: small-caps;}
-    span.underline{text-decoration: underline;}
-    div.column{display: inline-block; vertical-align: top; width: 50%;}
-    div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
-    ul.task-list{list-style: none;}
-    .display.math{display: block; text-align: center; margin: 0.5rem auto;}
+  <title>Untitled</title>
+  <style type="text/css">
+      code{white-space: pre-wrap;}
+      span.smallcaps{font-variant: small-caps;}
+      span.underline{text-decoration: underline;}
+      div.column{display: inline-block; vertical-align: top; width: 50%;}
   </style>
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
-<h1 id="how-to-download-and-install-oletools">How to Download and
-Install oletools</h1>
+<h1 id="how-to-download-and-install-oletools">How to Download and Install oletools</h1>
 <h2 id="pre-requisites">Pre-requisites</h2>
-<p>The recommended Python version to run oletools is the latest
-<strong>Python 3.x</strong> (3.12 for now). Python 2.7 is still
-supported for the moment, even if it reached end of life in 2020 (for
-projects still using Python 2/PyPy 2 such as ViperMonkey). It is highly
-recommended to switch to Python 3 if possible.</p>
-<h2
-id="recommended-way-to-downloadinstallupdate-oletools-pip-or-pipx">Recommended
-way to Download+Install/Update oletools: pip or pipx</h2>
-<p>Pip is included with Python since version 2.7.9 and 3.4. If it is not
-installed on your system, either upgrade Python or see
-https://pip.pypa.io/en/stable/installing/</p>
+<p>The recommended Python version to run oletools is the latest <strong>Python 3.x</strong> (3.12 for now). Python 2.7 is still supported for the moment, even if it reached end of life in 2020 (for projects still using Python 2/PyPy 2 such as ViperMonkey). It is highly recommended to switch to Python 3 if possible.</p>
+<h2 id="recommended-way-to-downloadinstallupdate-oletools-pip-or-pipx">Recommended way to Download+Install/Update oletools: pip or pipx</h2>
+<p>Pip is included with Python since version 2.7.9 and 3.4. If it is not installed on your system, either upgrade Python or see https://pip.pypa.io/en/stable/installing/</p>
 <h3 id="linux-mac-osx-unix">Linux, Mac OSX, Unix</h3>
-<p>To download and install/update the latest release version of oletools
-with all its dependencies, run the following command in a shell:</p>
+<p>To download and install/update the latest release version of oletools with all its dependencies, run the following command in a shell:</p>
 <pre class="text"><code>sudo -H pip install -U oletools[full]</code></pre>
-<p>The keyword <code>[full]</code> means that all optional dependencies
-will be installed, such as XLMMacroDeobfuscator. If you prefer a lighter
-version without optional dependencies, use the following command
-instead:</p>
+<p>The keyword <code>[full]</code> means that all optional dependencies will be installed, such as XLMMacroDeobfuscator. If you prefer a lighter version without optional dependencies, use the following command instead:</p>
 <pre class="text"><code>sudo -H pip install -U oletools</code></pre>
-<p>Replace <code>pip</code> by <code>pip3</code> or <code>pip2</code> to
-install on a specific Python version.</p>
-<p>On some Linux distributions, it might not be allowed to install
-system-wide python packages with pip. In that case, pipx may be a better
-alternative to install oletools in a user virtual environment, and to
-install the command-line scripts oleid, olevba, etc:</p>
+<p>Replace <code>pip</code> by <code>pip3</code> or <code>pip2</code> to install on a specific Python version.</p>
+<p>On some Linux distributions, it might not be allowed to install system-wide python packages with pip. In that case, pipx may be a better alternative to install oletools in a user virtual environment, and to install the command-line scripts oleid, olevba, etc:</p>
 <pre class="text"><code>pipx install oletools</code></pre>
-<p><strong>Important</strong>: Since version 0.50, pip will
-automatically create convenient command-line scripts in /usr/local/bin
-to run all the oletools from any directory.</p>
+<p><strong>Important</strong>: Since version 0.50, pip will automatically create convenient command-line scripts in /usr/local/bin to run all the oletools from any directory.</p>
 <h3 id="windows">Windows</h3>
-<p>To download and install/update the latest release version of oletools
-with all its dependencies, run the following command in a cmd
-window:</p>
+<p>To download and install/update the latest release version of oletools with all its dependencies, run the following command in a cmd window:</p>
 <pre class="text"><code>pip install -U oletools[full]</code></pre>
-<p>The keyword <code>[full]</code> means that all optional dependencies
-will be installed, such as XLMMacroDeobfuscator. If you prefer a lighter
-version without optional dependencies, use the following command
-instead:</p>
+<p>The keyword <code>[full]</code> means that all optional dependencies will be installed, such as XLMMacroDeobfuscator. If you prefer a lighter version without optional dependencies, use the following command instead:</p>
 <pre class="text"><code>pip install -U oletools</code></pre>
-<p>Replace <code>pip</code> by <code>pip3</code> or <code>pip2</code> to
-install on a specific Python version.</p>
-<p><strong>Note</strong>: with Python 3, you may need to open a cmd
-window with Administrator privileges in order to run pip and install for
-all users. If that is not possible, you may also install only for the
-current user by adding the <code>--user</code> option:</p>
+<p>Replace <code>pip</code> by <code>pip3</code> or <code>pip2</code> to install on a specific Python version.</p>
+<p><strong>Note</strong>: with Python 3, you may need to open a cmd window with Administrator privileges in order to run pip and install for all users. If that is not possible, you may also install only for the current user by adding the <code>--user</code> option:</p>
 <pre class="text"><code>pip3 install -U --user oletools</code></pre>
-<p><strong>Important</strong>: Since version 0.50, pip will
-automatically create convenient command-line scripts to run all the
-oletools from any directory: olevba, mraptor, oleid, rtfobj, etc.</p>
-<h2 id="how-to-install-the-latest-development-version">How to install
-the latest development version</h2>
-<p>If you want to benefit from the latest improvements in the
-development version, you may also use pip:</p>
+<p><strong>Important</strong>: Since version 0.50, pip will automatically create convenient command-line scripts to run all the oletools from any directory: olevba, mraptor, oleid, rtfobj, etc.</p>
+<h2 id="how-to-install-the-latest-development-version">How to install the latest development version</h2>
+<p>If you want to benefit from the latest improvements in the development version, you may also use pip:</p>
 <h3 id="linux-mac-osx-unix-1">Linux, Mac OSX, Unix</h3>
 <pre class="text"><code>sudo -H pip install -U https://github.com/decalage2/oletools/archive/master.zip</code></pre>
-<p>Note that it will install oletools without optional dependencies such
-as XLMMacroDeobfuscator, so you may need to install them separately.</p>
-<p>Replace <code>pip</code> by <code>pip3</code> or <code>pip2</code> to
-install on a specific Python version.</p>
+<p>Note that it will install oletools without optional dependencies such as XLMMacroDeobfuscator, so you may need to install them separately.</p>
+<p>Replace <code>pip</code> by <code>pip3</code> or <code>pip2</code> to install on a specific Python version.</p>
 <h3 id="windows-1">Windows</h3>
 <pre class="text"><code>pip install -U https://github.com/decalage2/oletools/archive/master.zip</code></pre>
-<p>Note that it will install oletools without optional dependencies such
-as XLMMacroDeobfuscator, so you may need to install them separately.</p>
-<p>Replace <code>pip</code> by <code>pip3</code> or <code>pip2</code> to
-install on a specific Python version.</p>
-<p><strong>Note</strong>: with Python 3, you may need to open a cmd
-window with Administrator privileges in order to run pip and install for
-all users. If that is not possible, you may also install only for the
-current user by adding the <code>--user</code> option:</p>
+<p>Note that it will install oletools without optional dependencies such as XLMMacroDeobfuscator, so you may need to install them separately.</p>
+<p>Replace <code>pip</code> by <code>pip3</code> or <code>pip2</code> to install on a specific Python version.</p>
+<p><strong>Note</strong>: with Python 3, you may need to open a cmd window with Administrator privileges in order to run pip and install for all users. If that is not possible, you may also install only for the current user by adding the <code>--user</code> option:</p>
 <pre class="text"><code>pip3 install -U --user https://github.com/decalage2/oletools/archive/master.zip</code></pre>
-<h2 id="how-to-install-offline---computer-without-internet-access">How
-to install offline - Computer without Internet access</h2>
-<p>First, download the oletools archive on a computer with Internet
-access: * Latest stable version: from https://pypi.org/project/oletools/
-or https://github.com/decalage2/oletools/releases * Development version:
-https://github.com/decalage2/oletools/archive/master.zip</p>
+<h2 id="how-to-install-offline---computer-without-internet-access">How to install offline - Computer without Internet access</h2>
+<p>First, download the oletools archive on a computer with Internet access: * Latest stable version: from https://pypi.org/project/oletools/ or https://github.com/decalage2/oletools/releases * Development version: https://github.com/decalage2/oletools/archive/master.zip</p>
 <p>Copy the archive file to the target computer.</p>
-<p>On Linux, Mac OSX, Unix, run the following command using the filename
-of the archive that you downloaded:</p>
+<p>On Linux, Mac OSX, Unix, run the following command using the filename of the archive that you downloaded:</p>
 <pre class="text"><code>sudo -H pip install -U oletools.zip</code></pre>
 <p>On Windows:</p>
 <pre class="text"><code>pip install -U oletools.zip</code></pre>
-<h2 id="old-school-install-using-setup.py">Old school install using
-setup.py</h2>
-<p>If you cannot use pip, it is still possible to run the setup.py
-script directly. However, this method will not create the command-line
-scripts automatically.</p>
-<p>First, download the oletools archive: * Latest stable version: from
-https://github.com/decalage2/oletools/releases * Development version:
-https://github.com/decalage2/oletools/archive/master.zip</p>
-<p>Then extract the archive, open a shell and go to the oletools
-directory.</p>
+<h2 id="old-school-install-using-setup.py">Old school install using setup.py</h2>
+<p>If you cannot use pip, it is still possible to run the setup.py script directly. However, this method will not create the command-line scripts automatically.</p>
+<p>First, download the oletools archive: * Latest stable version: from https://github.com/decalage2/oletools/releases * Development version: https://github.com/decalage2/oletools/archive/master.zip</p>
+<p>Then extract the archive, open a shell and go to the oletools directory.</p>
 <h3 id="linux-mac-osx-unix-2">Linux, Mac OSX, Unix</h3>
 <pre class="text"><code>sudo -H python setup.py install</code></pre>
 <h3 id="windows-2">Windows:</h3>
 <pre class="text"><code>python setup.py install</code></pre>
 <hr />
-<h2 id="python-oletools-documentation">python-oletools
-documentation</h2>
+<h2 id="python-oletools-documentation">python-oletools documentation</h2>
 <ul>
 <li><a href="Home.html">Home</a></li>
 <li><a href="License.html">License</a></li>
 <li><a href="Install.html">Install</a></li>
-<li><a href="Contribute.html">Contribute</a>, Suggest Improvements or
-Report Issues</li>
+<li><a href="Contribute.html">Contribute</a>, Suggest Improvements or Report Issues</li>
 <li>Tools:
 <ul>
 <li><a href="mraptor.html">mraptor</a></li>

--- a/oletools/doc/License.html
+++ b/oletools/doc/License.html
@@ -4,189 +4,28 @@
   <meta charset="utf-8" />
   <meta name="generator" content="pandoc" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
-  <title>-</title>
-  <style>
-    html {
-      line-height: 1.5;
-      font-family: Georgia, serif;
-      font-size: 20px;
-      color: #1a1a1a;
-      background-color: #fdfdfd;
-    }
-    body {
-      margin: 0 auto;
-      max-width: 36em;
-      padding-left: 50px;
-      padding-right: 50px;
-      padding-top: 50px;
-      padding-bottom: 50px;
-      hyphens: auto;
-      overflow-wrap: break-word;
-      text-rendering: optimizeLegibility;
-      font-kerning: normal;
-    }
-    @media (max-width: 600px) {
-      body {
-        font-size: 0.9em;
-        padding: 1em;
-      }
-      h1 {
-        font-size: 1.8em;
-      }
-    }
-    @media print {
-      body {
-        background-color: transparent;
-        color: black;
-        font-size: 12pt;
-      }
-      p, h2, h3 {
-        orphans: 3;
-        widows: 3;
-      }
-      h2, h3, h4 {
-        page-break-after: avoid;
-      }
-    }
-    p {
-      margin: 1em 0;
-    }
-    a {
-      color: #1a1a1a;
-    }
-    a:visited {
-      color: #1a1a1a;
-    }
-    img {
-      max-width: 100%;
-    }
-    h1, h2, h3, h4, h5, h6 {
-      margin-top: 1.4em;
-    }
-    h5, h6 {
-      font-size: 1em;
-      font-style: italic;
-    }
-    h6 {
-      font-weight: normal;
-    }
-    ol, ul {
-      padding-left: 1.7em;
-      margin-top: 1em;
-    }
-    li > ol, li > ul {
-      margin-top: 0;
-    }
-    blockquote {
-      margin: 1em 0 1em 1.7em;
-      padding-left: 1em;
-      border-left: 2px solid #e6e6e6;
-      color: #606060;
-    }
-    code {
-      font-family: Menlo, Monaco, 'Lucida Console', Consolas, monospace;
-      font-size: 85%;
-      margin: 0;
-    }
-    pre {
-      margin: 1em 0;
-      overflow: auto;
-    }
-    pre code {
-      padding: 0;
-      overflow: visible;
-      overflow-wrap: normal;
-    }
-    .sourceCode {
-     background-color: transparent;
-     overflow: visible;
-    }
-    hr {
-      background-color: #1a1a1a;
-      border: none;
-      height: 1px;
-      margin: 1em 0;
-    }
-    table {
-      margin: 1em 0;
-      border-collapse: collapse;
-      width: 100%;
-      overflow-x: auto;
-      display: block;
-      font-variant-numeric: lining-nums tabular-nums;
-    }
-    table caption {
-      margin-bottom: 0.75em;
-    }
-    tbody {
-      margin-top: 0.5em;
-      border-top: 1px solid #1a1a1a;
-      border-bottom: 1px solid #1a1a1a;
-    }
-    th {
-      border-top: 1px solid #1a1a1a;
-      padding: 0.25em 0.5em 0.25em 0.5em;
-    }
-    td {
-      padding: 0.125em 0.5em 0.25em 0.5em;
-    }
-    header {
-      margin-bottom: 4em;
-      text-align: center;
-    }
-    #TOC li {
-      list-style: none;
-    }
-    #TOC ul {
-      padding-left: 1.3em;
-    }
-    #TOC > ul {
-      padding-left: 0;
-    }
-    #TOC a:not(:hover) {
-      text-decoration: none;
-    }
-    code{white-space: pre-wrap;}
-    span.smallcaps{font-variant: small-caps;}
-    span.underline{text-decoration: underline;}
-    div.column{display: inline-block; vertical-align: top; width: 50%;}
-    div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
-    ul.task-list{list-style: none;}
-    .display.math{display: block; text-align: center; margin: 0.5rem auto;}
+  <title>Untitled</title>
+  <style type="text/css">
+      code{white-space: pre-wrap;}
+      span.smallcaps{font-variant: small-caps;}
+      span.underline{text-decoration: underline;}
+      div.column{display: inline-block; vertical-align: top; width: 50%;}
   </style>
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
 <h1 id="license-for-python-oletools">License for python-oletools</h1>
-<p>This license applies to the <a
-href="http://www.decalage.info/python/oletools">python-oletools</a>
-package, apart from the thirdparty folder which contains third-party
-files published with their own license.</p>
-<p>The python-oletools package is copyright (c) 2012-2024 Philippe
-Lagadec (<a
-href="http://www.decalage.info">http://www.decalage.info</a>)</p>
+<p>This license applies to the <a href="http://www.decalage.info/python/oletools">python-oletools</a> package, apart from the thirdparty folder which contains third-party files published with their own license.</p>
+<p>The python-oletools package is copyright (c) 2012-2025 Philippe Lagadec (<a href="http://www.decalage.info" class="uri">http://www.decalage.info</a>)</p>
 <p>All rights reserved.</p>
-<p>Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:</p>
+<p>Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:</p>
 <ul>
-<li>Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.</li>
-<li>Redistributions in binary form must reproduce the above copyright
-notice, this list of conditions and the following disclaimer in the
-documentation and/or other materials provided with the
-distribution.</li>
+<li>Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.</li>
+<li>Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.</li>
 </ul>
-<p>THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-“AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
-TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</p>
+<p>THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</p>
 <table>
 <tbody>
 <tr class="odd">
@@ -194,35 +33,18 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</p>
 </tr>
 </tbody>
 </table>
-<p>olevba contains modified source code from the <a
-href="https://github.com/unixfreak0037/officeparser">officeparser</a>
-project, published under the following MIT License (MIT):</p>
+<p>olevba contains modified source code from the <a href="https://github.com/unixfreak0037/officeparser">officeparser</a> project, published under the following MIT License (MIT):</p>
 <p>officeparser is copyright (c) 2014 John William Davison</p>
-<p>Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-“Software”), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:</p>
-<p>The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.</p>
-<p>THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</p>
+<p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:</p>
+<p>The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.</p>
+<p>THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</p>
 <hr />
-<h2 id="python-oletools-documentation">python-oletools
-documentation</h2>
+<h2 id="python-oletools-documentation">python-oletools documentation</h2>
 <ul>
 <li><a href="Home.html">Home</a></li>
 <li><a href="License.html">License</a></li>
 <li><a href="Install.html">Install</a></li>
-<li><a href="Contribute.html">Contribute</a>, Suggest Improvements or
-Report Issues</li>
+<li><a href="Contribute.html">Contribute</a>, Suggest Improvements or Report Issues</li>
 <li>Tools:
 <ul>
 <li><a href="mraptor.html">mraptor</a></li>

--- a/oletools/doc/License.md
+++ b/oletools/doc/License.md
@@ -4,7 +4,7 @@ License for python-oletools
 This license applies to the [python-oletools](http://www.decalage.info/python/oletools) package, apart from the 
 thirdparty folder which contains third-party files published with their own license.
 
-The python-oletools package is copyright (c) 2012-2024 Philippe Lagadec ([http://www.decalage.info](http://www.decalage.info))
+The python-oletools package is copyright (c) 2012-2025 Philippe Lagadec ([http://www.decalage.info](http://www.decalage.info))
 
 All rights reserved.
 

--- a/oletools/doc/mraptor.html
+++ b/oletools/doc/mraptor.html
@@ -4,177 +4,25 @@
   <meta charset="utf-8" />
   <meta name="generator" content="pandoc" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
-  <title>-</title>
-  <style>
-    html {
-      line-height: 1.5;
-      font-family: Georgia, serif;
-      font-size: 20px;
-      color: #1a1a1a;
-      background-color: #fdfdfd;
-    }
-    body {
-      margin: 0 auto;
-      max-width: 36em;
-      padding-left: 50px;
-      padding-right: 50px;
-      padding-top: 50px;
-      padding-bottom: 50px;
-      hyphens: auto;
-      overflow-wrap: break-word;
-      text-rendering: optimizeLegibility;
-      font-kerning: normal;
-    }
-    @media (max-width: 600px) {
-      body {
-        font-size: 0.9em;
-        padding: 1em;
-      }
-      h1 {
-        font-size: 1.8em;
-      }
-    }
-    @media print {
-      body {
-        background-color: transparent;
-        color: black;
-        font-size: 12pt;
-      }
-      p, h2, h3 {
-        orphans: 3;
-        widows: 3;
-      }
-      h2, h3, h4 {
-        page-break-after: avoid;
-      }
-    }
-    p {
-      margin: 1em 0;
-    }
-    a {
-      color: #1a1a1a;
-    }
-    a:visited {
-      color: #1a1a1a;
-    }
-    img {
-      max-width: 100%;
-    }
-    h1, h2, h3, h4, h5, h6 {
-      margin-top: 1.4em;
-    }
-    h5, h6 {
-      font-size: 1em;
-      font-style: italic;
-    }
-    h6 {
-      font-weight: normal;
-    }
-    ol, ul {
-      padding-left: 1.7em;
-      margin-top: 1em;
-    }
-    li > ol, li > ul {
-      margin-top: 0;
-    }
-    blockquote {
-      margin: 1em 0 1em 1.7em;
-      padding-left: 1em;
-      border-left: 2px solid #e6e6e6;
-      color: #606060;
-    }
-    code {
-      font-family: Menlo, Monaco, 'Lucida Console', Consolas, monospace;
-      font-size: 85%;
-      margin: 0;
-    }
-    pre {
-      margin: 1em 0;
-      overflow: auto;
-    }
-    pre code {
-      padding: 0;
-      overflow: visible;
-      overflow-wrap: normal;
-    }
-    .sourceCode {
-     background-color: transparent;
-     overflow: visible;
-    }
-    hr {
-      background-color: #1a1a1a;
-      border: none;
-      height: 1px;
-      margin: 1em 0;
-    }
-    table {
-      margin: 1em 0;
-      border-collapse: collapse;
-      width: 100%;
-      overflow-x: auto;
-      display: block;
-      font-variant-numeric: lining-nums tabular-nums;
-    }
-    table caption {
-      margin-bottom: 0.75em;
-    }
-    tbody {
-      margin-top: 0.5em;
-      border-top: 1px solid #1a1a1a;
-      border-bottom: 1px solid #1a1a1a;
-    }
-    th {
-      border-top: 1px solid #1a1a1a;
-      padding: 0.25em 0.5em 0.25em 0.5em;
-    }
-    td {
-      padding: 0.125em 0.5em 0.25em 0.5em;
-    }
-    header {
-      margin-bottom: 4em;
-      text-align: center;
-    }
-    #TOC li {
-      list-style: none;
-    }
-    #TOC ul {
-      padding-left: 1.3em;
-    }
-    #TOC > ul {
-      padding-left: 0;
-    }
-    #TOC a:not(:hover) {
-      text-decoration: none;
-    }
-    code{white-space: pre-wrap;}
-    span.smallcaps{font-variant: small-caps;}
-    span.underline{text-decoration: underline;}
-    div.column{display: inline-block; vertical-align: top; width: 50%;}
-    div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
-    ul.task-list{list-style: none;}
-    .display.math{display: block; text-align: center; margin: 0.5rem auto;}
+  <title>Untitled</title>
+  <style type="text/css">
+      code{white-space: pre-wrap;}
+      span.smallcaps{font-variant: small-caps;}
+      span.underline{text-decoration: underline;}
+      div.column{display: inline-block; vertical-align: top; width: 50%;}
   </style>
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
 <h1 id="mraptor-macroraptor">mraptor (MacroRaptor)</h1>
-<p>mraptor is a tool designed to detect most malicious VBA Macros using
-generic heuristics. Unlike antivirus engines, it does not rely on
-signatures.</p>
-<p>In a nutshell, mraptor detects keywords corresponding to the three
-following types of behaviour that are present in clear text in almost
-any macro malware: - A: Auto-execution trigger - W: Write to the file
-system or memory - X: Execute a file or any payload outside the VBA
-context</p>
-<p>mraptor considers that a macro is suspicious when A and (W or X) is
-true.</p>
-<p>For more information about mraptor’s detection algorithm, see the
-article <a href="http://www.decalage.info/mraptor">How to detect most
-malicious macros without an antivirus</a>.</p>
-<p>mraptor can be used either as a command-line tool, or as a python
-module from your own applications.</p>
-<p>It is part of the <a
-href="http://www.decalage.info/python/oletools">python-oletools</a>
-package.</p>
+<p>mraptor is a tool designed to detect most malicious VBA Macros using generic heuristics. Unlike antivirus engines, it does not rely on signatures.</p>
+<p>In a nutshell, mraptor detects keywords corresponding to the three following types of behaviour that are present in clear text in almost any macro malware: - A: Auto-execution trigger - W: Write to the file system or memory - X: Execute a file or any payload outside the VBA context</p>
+<p>mraptor considers that a macro is suspicious when A and (W or X) is true.</p>
+<p>For more information about mraptor’s detection algorithm, see the article <a href="http://www.decalage.info/mraptor">How to detect most malicious macros without an antivirus</a>.</p>
+<p>mraptor can be used either as a command-line tool, or as a python module from your own applications.</p>
+<p>It is part of the <a href="http://www.decalage.info/python/oletools">python-oletools</a> package.</p>
 <h2 id="usage">Usage</h2>
 <pre class="text"><code>Usage: mraptor [options] &lt;filename&gt; [filename2 ...]
 
@@ -202,34 +50,24 @@ An exit code is returned based on the analysis result:
 <h3 id="examples">Examples</h3>
 <p>Scan a single file:</p>
 <pre class="text"><code>mraptor file.doc</code></pre>
-<p>Scan a single file, stored in a Zip archive with password
-“infected”:</p>
+<p>Scan a single file, stored in a Zip archive with password “infected”:</p>
 <pre class="text"><code>mraptor malicious_file.xls.zip -z infected</code></pre>
 <p>Scan a collection of files stored in a folder:</p>
 <pre class="text"><code>mraptor &quot;MalwareZoo/VBA/*&quot;</code></pre>
-<p><strong>Important</strong>: on Linux/MacOSX, always add double quotes
-around a file name when you use wildcards such as <code>*</code> and
-<code>?</code>. Otherwise, the shell may replace the argument with the
-actual list of files matching the wildcards before starting the
-script.</p>
+<p><strong>Important</strong>: on Linux/MacOSX, always add double quotes around a file name when you use wildcards such as <code>*</code> and <code>?</code>. Otherwise, the shell may replace the argument with the actual list of files matching the wildcards before starting the script.</p>
 <p><img src="mraptor1.png" /></p>
 <h2 id="python-3-support---mraptor3">Python 3 support - mraptor3</h2>
-<p>Since v0.54, mraptor is fully compatible with both Python 2 and 3.
-There is no need to use mraptor3 anymore, however it is still present
-for backward compatibility.</p>
+<p>Since v0.54, mraptor is fully compatible with both Python 2 and 3. There is no need to use mraptor3 anymore, however it is still present for backward compatibility.</p>
 <hr />
-<h2 id="how-to-use-mraptor-in-python-applications">How to use mraptor in
-Python applications</h2>
+<h2 id="how-to-use-mraptor-in-python-applications">How to use mraptor in Python applications</h2>
 <p>TODO</p>
 <hr />
-<h2 id="python-oletools-documentation">python-oletools
-documentation</h2>
+<h2 id="python-oletools-documentation">python-oletools documentation</h2>
 <ul>
 <li><a href="Home.html">Home</a></li>
 <li><a href="License.html">License</a></li>
 <li><a href="Install.html">Install</a></li>
-<li><a href="Contribute.html">Contribute</a>, Suggest Improvements or
-Report Issues</li>
+<li><a href="Contribute.html">Contribute</a>, Suggest Improvements or Report Issues</li>
 <li>Tools:
 <ul>
 <li><a href="mraptor.html">mraptor</a></li>

--- a/oletools/doc/olebrowse.html
+++ b/oletools/doc/olebrowse.html
@@ -4,182 +4,30 @@
   <meta charset="utf-8" />
   <meta name="generator" content="pandoc" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
-  <title>-</title>
-  <style>
-    html {
-      line-height: 1.5;
-      font-family: Georgia, serif;
-      font-size: 20px;
-      color: #1a1a1a;
-      background-color: #fdfdfd;
-    }
-    body {
-      margin: 0 auto;
-      max-width: 36em;
-      padding-left: 50px;
-      padding-right: 50px;
-      padding-top: 50px;
-      padding-bottom: 50px;
-      hyphens: auto;
-      overflow-wrap: break-word;
-      text-rendering: optimizeLegibility;
-      font-kerning: normal;
-    }
-    @media (max-width: 600px) {
-      body {
-        font-size: 0.9em;
-        padding: 1em;
-      }
-      h1 {
-        font-size: 1.8em;
-      }
-    }
-    @media print {
-      body {
-        background-color: transparent;
-        color: black;
-        font-size: 12pt;
-      }
-      p, h2, h3 {
-        orphans: 3;
-        widows: 3;
-      }
-      h2, h3, h4 {
-        page-break-after: avoid;
-      }
-    }
-    p {
-      margin: 1em 0;
-    }
-    a {
-      color: #1a1a1a;
-    }
-    a:visited {
-      color: #1a1a1a;
-    }
-    img {
-      max-width: 100%;
-    }
-    h1, h2, h3, h4, h5, h6 {
-      margin-top: 1.4em;
-    }
-    h5, h6 {
-      font-size: 1em;
-      font-style: italic;
-    }
-    h6 {
-      font-weight: normal;
-    }
-    ol, ul {
-      padding-left: 1.7em;
-      margin-top: 1em;
-    }
-    li > ol, li > ul {
-      margin-top: 0;
-    }
-    blockquote {
-      margin: 1em 0 1em 1.7em;
-      padding-left: 1em;
-      border-left: 2px solid #e6e6e6;
-      color: #606060;
-    }
-    code {
-      font-family: Menlo, Monaco, 'Lucida Console', Consolas, monospace;
-      font-size: 85%;
-      margin: 0;
-    }
-    pre {
-      margin: 1em 0;
-      overflow: auto;
-    }
-    pre code {
-      padding: 0;
-      overflow: visible;
-      overflow-wrap: normal;
-    }
-    .sourceCode {
-     background-color: transparent;
-     overflow: visible;
-    }
-    hr {
-      background-color: #1a1a1a;
-      border: none;
-      height: 1px;
-      margin: 1em 0;
-    }
-    table {
-      margin: 1em 0;
-      border-collapse: collapse;
-      width: 100%;
-      overflow-x: auto;
-      display: block;
-      font-variant-numeric: lining-nums tabular-nums;
-    }
-    table caption {
-      margin-bottom: 0.75em;
-    }
-    tbody {
-      margin-top: 0.5em;
-      border-top: 1px solid #1a1a1a;
-      border-bottom: 1px solid #1a1a1a;
-    }
-    th {
-      border-top: 1px solid #1a1a1a;
-      padding: 0.25em 0.5em 0.25em 0.5em;
-    }
-    td {
-      padding: 0.125em 0.5em 0.25em 0.5em;
-    }
-    header {
-      margin-bottom: 4em;
-      text-align: center;
-    }
-    #TOC li {
-      list-style: none;
-    }
-    #TOC ul {
-      padding-left: 1.3em;
-    }
-    #TOC > ul {
-      padding-left: 0;
-    }
-    #TOC a:not(:hover) {
-      text-decoration: none;
-    }
-    code{white-space: pre-wrap;}
-    span.smallcaps{font-variant: small-caps;}
-    span.underline{text-decoration: underline;}
-    div.column{display: inline-block; vertical-align: top; width: 50%;}
-    div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
-    ul.task-list{list-style: none;}
-    .display.math{display: block; text-align: center; margin: 0.5rem auto;}
+  <title>Untitled</title>
+  <style type="text/css">
+      code{white-space: pre-wrap;}
+      span.smallcaps{font-variant: small-caps;}
+      span.underline{text-decoration: underline;}
+      div.column{display: inline-block; vertical-align: top; width: 50%;}
   </style>
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
 <h1 id="olebrowse">olebrowse</h1>
-<p>olebrowse is a simple GUI to browse OLE files (e.g. MS Word, Excel,
-Powerpoint documents), to view and extract individual data streams.</p>
-<p>It is part of the <a
-href="http://www.decalage.info/python/oletools">python-oletools</a>
-package.</p>
+<p>olebrowse is a simple GUI to browse OLE files (e.g. MS Word, Excel, Powerpoint documents), to view and extract individual data streams.</p>
+<p>It is part of the <a href="http://www.decalage.info/python/oletools">python-oletools</a> package.</p>
 <h2 id="dependencies">Dependencies</h2>
-<p>olebrowse requires <a
-href="https://en.wikipedia.org/wiki/Tkinter">Tkinter</a>. On Windows and
-MacOSX, it should be installed with Python, and olebrowse should work
-out of the box.</p>
-<p>However, on Linux it might be necessary to install the tkinter
-package for Python separately. For example, on Ubuntu this is done with
-the following command:</p>
+<p>olebrowse requires <a href="https://en.wikipedia.org/wiki/Tkinter">Tkinter</a>. On Windows and MacOSX, it should be installed with Python, and olebrowse should work out of the box.</p>
+<p>However, on Linux it might be necessary to install the tkinter package for Python separately. For example, on Ubuntu this is done with the following command:</p>
 <pre><code>sudo apt-get install python-tk</code></pre>
 <p>And for Python 3:</p>
 <pre><code>sudo apt-get install python3-tk</code></pre>
 <h2 id="usage">Usage</h2>
 <pre><code>olebrowse [file]</code></pre>
-<p>If you provide a file it will be opened, else a dialog will allow you
-to browse folders to open a file. Then if it is a valid OLE file, the
-list of data streams will be displayed. You can select a stream, and
-then either view its content in a builtin hexadecimal viewer, or save it
-to a file for further analysis.</p>
+<p>If you provide a file it will be opened, else a dialog will allow you to browse folders to open a file. Then if it is a valid OLE file, the list of data streams will be displayed. You can select a stream, and then either view its content in a builtin hexadecimal viewer, or save it to a file for further analysis.</p>
 <h2 id="screenshots">Screenshots</h2>
 <p>Main menu, showing all streams in the OLE file:</p>
 <p><img src="olebrowse1_menu.png" /></p>
@@ -188,14 +36,12 @@ to a file for further analysis.</p>
 <p>Hex view for a stream:</p>
 <p><img src="olebrowse3_hexview.png" /></p>
 <hr />
-<h2 id="python-oletools-documentation">python-oletools
-documentation</h2>
+<h2 id="python-oletools-documentation">python-oletools documentation</h2>
 <ul>
 <li><a href="Home.html">Home</a></li>
 <li><a href="License.html">License</a></li>
 <li><a href="Install.html">Install</a></li>
-<li><a href="Contribute.html">Contribute</a>, Suggest Improvements or
-Report Issues</li>
+<li><a href="Contribute.html">Contribute</a>, Suggest Improvements or Report Issues</li>
 <li>Tools:
 <ul>
 <li><a href="mraptor.html">mraptor</a></li>

--- a/oletools/doc/oledir.html
+++ b/oletools/doc/oledir.html
@@ -4,166 +4,22 @@
   <meta charset="utf-8" />
   <meta name="generator" content="pandoc" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
-  <title>-</title>
-  <style>
-    html {
-      line-height: 1.5;
-      font-family: Georgia, serif;
-      font-size: 20px;
-      color: #1a1a1a;
-      background-color: #fdfdfd;
-    }
-    body {
-      margin: 0 auto;
-      max-width: 36em;
-      padding-left: 50px;
-      padding-right: 50px;
-      padding-top: 50px;
-      padding-bottom: 50px;
-      hyphens: auto;
-      overflow-wrap: break-word;
-      text-rendering: optimizeLegibility;
-      font-kerning: normal;
-    }
-    @media (max-width: 600px) {
-      body {
-        font-size: 0.9em;
-        padding: 1em;
-      }
-      h1 {
-        font-size: 1.8em;
-      }
-    }
-    @media print {
-      body {
-        background-color: transparent;
-        color: black;
-        font-size: 12pt;
-      }
-      p, h2, h3 {
-        orphans: 3;
-        widows: 3;
-      }
-      h2, h3, h4 {
-        page-break-after: avoid;
-      }
-    }
-    p {
-      margin: 1em 0;
-    }
-    a {
-      color: #1a1a1a;
-    }
-    a:visited {
-      color: #1a1a1a;
-    }
-    img {
-      max-width: 100%;
-    }
-    h1, h2, h3, h4, h5, h6 {
-      margin-top: 1.4em;
-    }
-    h5, h6 {
-      font-size: 1em;
-      font-style: italic;
-    }
-    h6 {
-      font-weight: normal;
-    }
-    ol, ul {
-      padding-left: 1.7em;
-      margin-top: 1em;
-    }
-    li > ol, li > ul {
-      margin-top: 0;
-    }
-    blockquote {
-      margin: 1em 0 1em 1.7em;
-      padding-left: 1em;
-      border-left: 2px solid #e6e6e6;
-      color: #606060;
-    }
-    code {
-      font-family: Menlo, Monaco, 'Lucida Console', Consolas, monospace;
-      font-size: 85%;
-      margin: 0;
-    }
-    pre {
-      margin: 1em 0;
-      overflow: auto;
-    }
-    pre code {
-      padding: 0;
-      overflow: visible;
-      overflow-wrap: normal;
-    }
-    .sourceCode {
-     background-color: transparent;
-     overflow: visible;
-    }
-    hr {
-      background-color: #1a1a1a;
-      border: none;
-      height: 1px;
-      margin: 1em 0;
-    }
-    table {
-      margin: 1em 0;
-      border-collapse: collapse;
-      width: 100%;
-      overflow-x: auto;
-      display: block;
-      font-variant-numeric: lining-nums tabular-nums;
-    }
-    table caption {
-      margin-bottom: 0.75em;
-    }
-    tbody {
-      margin-top: 0.5em;
-      border-top: 1px solid #1a1a1a;
-      border-bottom: 1px solid #1a1a1a;
-    }
-    th {
-      border-top: 1px solid #1a1a1a;
-      padding: 0.25em 0.5em 0.25em 0.5em;
-    }
-    td {
-      padding: 0.125em 0.5em 0.25em 0.5em;
-    }
-    header {
-      margin-bottom: 4em;
-      text-align: center;
-    }
-    #TOC li {
-      list-style: none;
-    }
-    #TOC ul {
-      padding-left: 1.3em;
-    }
-    #TOC > ul {
-      padding-left: 0;
-    }
-    #TOC a:not(:hover) {
-      text-decoration: none;
-    }
-    code{white-space: pre-wrap;}
-    span.smallcaps{font-variant: small-caps;}
-    span.underline{text-decoration: underline;}
-    div.column{display: inline-block; vertical-align: top; width: 50%;}
-    div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
-    ul.task-list{list-style: none;}
-    .display.math{display: block; text-align: center; margin: 0.5rem auto;}
+  <title>Untitled</title>
+  <style type="text/css">
+      code{white-space: pre-wrap;}
+      span.smallcaps{font-variant: small-caps;}
+      span.underline{text-decoration: underline;}
+      div.column{display: inline-block; vertical-align: top; width: 50%;}
   </style>
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
 <h1 id="oledir">oledir</h1>
-<p>oledir is a script to display all the directory entries of an OLE
-file, including free and orphaned entries.</p>
-<p>It can be used either as a command-line tool, or as a python module
-from your own applications.</p>
-<p>It is part of the <a
-href="http://www.decalage.info/python/oletools">python-oletools</a>
-package.</p>
+<p>oledir is a script to display all the directory entries of an OLE file, including free and orphaned entries.</p>
+<p>It can be used either as a command-line tool, or as a python module from your own applications.</p>
+<p>It is part of the <a href="http://www.decalage.info/python/oletools">python-oletools</a> package.</p>
 <h2 id="usage">Usage</h2>
 <pre class="text"><code>Usage: oledir [options] &lt;filename&gt; [filename2 ...]
 
@@ -182,18 +38,15 @@ Options:
 <pre class="text"><code>oledir file.doc</code></pre>
 <p><img src="oledir.png" /></p>
 <hr />
-<h2 id="how-to-use-oledir-in-python-applications">How to use oledir in
-Python applications</h2>
+<h2 id="how-to-use-oledir-in-python-applications">How to use oledir in Python applications</h2>
 <p>TODO</p>
 <hr />
-<h2 id="python-oletools-documentation">python-oletools
-documentation</h2>
+<h2 id="python-oletools-documentation">python-oletools documentation</h2>
 <ul>
 <li><a href="Home.html">Home</a></li>
 <li><a href="License.html">License</a></li>
 <li><a href="Install.html">Install</a></li>
-<li><a href="Contribute.html">Contribute</a>, Suggest Improvements or
-Report Issues</li>
+<li><a href="Contribute.html">Contribute</a>, Suggest Improvements or Report Issues</li>
 <li>Tools:
 <ul>
 <li><a href="mraptor.html">mraptor</a></li>

--- a/oletools/doc/oleid.html
+++ b/oletools/doc/oleid.html
@@ -4,233 +4,89 @@
   <meta charset="utf-8" />
   <meta name="generator" content="pandoc" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
-  <title>-</title>
-  <style>
-    html {
-      line-height: 1.5;
-      font-family: Georgia, serif;
-      font-size: 20px;
-      color: #1a1a1a;
-      background-color: #fdfdfd;
-    }
-    body {
-      margin: 0 auto;
-      max-width: 36em;
-      padding-left: 50px;
-      padding-right: 50px;
-      padding-top: 50px;
-      padding-bottom: 50px;
-      hyphens: auto;
-      overflow-wrap: break-word;
-      text-rendering: optimizeLegibility;
-      font-kerning: normal;
-    }
-    @media (max-width: 600px) {
-      body {
-        font-size: 0.9em;
-        padding: 1em;
-      }
-      h1 {
-        font-size: 1.8em;
-      }
-    }
-    @media print {
-      body {
-        background-color: transparent;
-        color: black;
-        font-size: 12pt;
-      }
-      p, h2, h3 {
-        orphans: 3;
-        widows: 3;
-      }
-      h2, h3, h4 {
-        page-break-after: avoid;
-      }
-    }
-    p {
-      margin: 1em 0;
-    }
-    a {
-      color: #1a1a1a;
-    }
-    a:visited {
-      color: #1a1a1a;
-    }
-    img {
-      max-width: 100%;
-    }
-    h1, h2, h3, h4, h5, h6 {
-      margin-top: 1.4em;
-    }
-    h5, h6 {
-      font-size: 1em;
-      font-style: italic;
-    }
-    h6 {
-      font-weight: normal;
-    }
-    ol, ul {
-      padding-left: 1.7em;
-      margin-top: 1em;
-    }
-    li > ol, li > ul {
-      margin-top: 0;
-    }
-    blockquote {
-      margin: 1em 0 1em 1.7em;
-      padding-left: 1em;
-      border-left: 2px solid #e6e6e6;
-      color: #606060;
-    }
-    code {
-      font-family: Menlo, Monaco, 'Lucida Console', Consolas, monospace;
-      font-size: 85%;
-      margin: 0;
-    }
-    pre {
-      margin: 1em 0;
-      overflow: auto;
-    }
-    pre code {
-      padding: 0;
-      overflow: visible;
-      overflow-wrap: normal;
-    }
-    .sourceCode {
-     background-color: transparent;
-     overflow: visible;
-    }
-    hr {
-      background-color: #1a1a1a;
-      border: none;
-      height: 1px;
-      margin: 1em 0;
-    }
-    table {
-      margin: 1em 0;
-      border-collapse: collapse;
-      width: 100%;
-      overflow-x: auto;
-      display: block;
-      font-variant-numeric: lining-nums tabular-nums;
-    }
-    table caption {
-      margin-bottom: 0.75em;
-    }
-    tbody {
-      margin-top: 0.5em;
-      border-top: 1px solid #1a1a1a;
-      border-bottom: 1px solid #1a1a1a;
-    }
-    th {
-      border-top: 1px solid #1a1a1a;
-      padding: 0.25em 0.5em 0.25em 0.5em;
-    }
-    td {
-      padding: 0.125em 0.5em 0.25em 0.5em;
-    }
-    header {
-      margin-bottom: 4em;
-      text-align: center;
-    }
-    #TOC li {
-      list-style: none;
-    }
-    #TOC ul {
-      padding-left: 1.3em;
-    }
-    #TOC > ul {
-      padding-left: 0;
-    }
-    #TOC a:not(:hover) {
-      text-decoration: none;
-    }
-    code{white-space: pre-wrap;}
-    span.smallcaps{font-variant: small-caps;}
-    span.underline{text-decoration: underline;}
-    div.column{display: inline-block; vertical-align: top; width: 50%;}
-    div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
-    ul.task-list{list-style: none;}
-    pre > code.sourceCode { white-space: pre; position: relative; }
-    pre > code.sourceCode > span { display: inline-block; line-height: 1.25; }
-    pre > code.sourceCode > span:empty { height: 1.2em; }
-    .sourceCode { overflow: visible; }
-    code.sourceCode > span { color: inherit; text-decoration: inherit; }
-    div.sourceCode { margin: 1em 0; }
-    pre.sourceCode { margin: 0; }
-    @media screen {
-    div.sourceCode { overflow: auto; }
-    }
-    @media print {
-    pre > code.sourceCode { white-space: pre-wrap; }
-    pre > code.sourceCode > span { text-indent: -5em; padding-left: 5em; }
-    }
-    pre.numberSource code
-      { counter-reset: source-line 0; }
-    pre.numberSource code > span
-      { position: relative; left: -4em; counter-increment: source-line; }
-    pre.numberSource code > span > a:first-child::before
-      { content: counter(source-line);
-        position: relative; left: -1em; text-align: right; vertical-align: baseline;
-        border: none; display: inline-block;
-        -webkit-touch-callout: none; -webkit-user-select: none;
-        -khtml-user-select: none; -moz-user-select: none;
-        -ms-user-select: none; user-select: none;
-        padding: 0 4px; width: 4em;
-        color: #aaaaaa;
-      }
-    pre.numberSource { margin-left: 3em; border-left: 1px solid #aaaaaa;  padding-left: 4px; }
-    div.sourceCode
-      {   }
-    @media screen {
-    pre > code.sourceCode > span > a:first-child::before { text-decoration: underline; }
-    }
-    code span.al { color: #ff0000; font-weight: bold; } /* Alert */
-    code span.an { color: #60a0b0; font-weight: bold; font-style: italic; } /* Annotation */
-    code span.at { color: #7d9029; } /* Attribute */
-    code span.bn { color: #40a070; } /* BaseN */
-    code span.bu { color: #008000; } /* BuiltIn */
-    code span.cf { color: #007020; font-weight: bold; } /* ControlFlow */
-    code span.ch { color: #4070a0; } /* Char */
-    code span.cn { color: #880000; } /* Constant */
-    code span.co { color: #60a0b0; font-style: italic; } /* Comment */
-    code span.cv { color: #60a0b0; font-weight: bold; font-style: italic; } /* CommentVar */
-    code span.do { color: #ba2121; font-style: italic; } /* Documentation */
-    code span.dt { color: #902000; } /* DataType */
-    code span.dv { color: #40a070; } /* DecVal */
-    code span.er { color: #ff0000; font-weight: bold; } /* Error */
-    code span.ex { } /* Extension */
-    code span.fl { color: #40a070; } /* Float */
-    code span.fu { color: #06287e; } /* Function */
-    code span.im { color: #008000; font-weight: bold; } /* Import */
-    code span.in { color: #60a0b0; font-weight: bold; font-style: italic; } /* Information */
-    code span.kw { color: #007020; font-weight: bold; } /* Keyword */
-    code span.op { color: #666666; } /* Operator */
-    code span.ot { color: #007020; } /* Other */
-    code span.pp { color: #bc7a00; } /* Preprocessor */
-    code span.sc { color: #4070a0; } /* SpecialChar */
-    code span.ss { color: #bb6688; } /* SpecialString */
-    code span.st { color: #4070a0; } /* String */
-    code span.va { color: #19177c; } /* Variable */
-    code span.vs { color: #4070a0; } /* VerbatimString */
-    code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warning */
-    .display.math{display: block; text-align: center; margin: 0.5rem auto;}
+  <title>Untitled</title>
+  <style type="text/css">
+      code{white-space: pre-wrap;}
+      span.smallcaps{font-variant: small-caps;}
+      span.underline{text-decoration: underline;}
+      div.column{display: inline-block; vertical-align: top; width: 50%;}
   </style>
+  <style type="text/css">
+a.sourceLine { display: inline-block; line-height: 1.25; }
+a.sourceLine { pointer-events: none; color: inherit; text-decoration: inherit; }
+a.sourceLine:empty { height: 1.2em; position: absolute; }
+.sourceCode { overflow: visible; }
+code.sourceCode { white-space: pre; position: relative; }
+div.sourceCode { margin: 1em 0; }
+pre.sourceCode { margin: 0; }
+@media screen {
+div.sourceCode { overflow: auto; }
+}
+@media print {
+code.sourceCode { white-space: pre-wrap; }
+a.sourceLine { text-indent: -1em; padding-left: 1em; }
+}
+pre.numberSource a.sourceLine
+  { position: relative; }
+pre.numberSource a.sourceLine:empty
+  { position: absolute; }
+pre.numberSource a.sourceLine::before
+  { content: attr(data-line-number);
+    position: absolute; left: -5em; text-align: right; vertical-align: baseline;
+    border: none; pointer-events: all;
+    -webkit-touch-callout: none; -webkit-user-select: none;
+    -khtml-user-select: none; -moz-user-select: none;
+    -ms-user-select: none; user-select: none;
+    padding: 0 4px; width: 4em;
+    color: #aaaaaa;
+  }
+pre.numberSource { margin-left: 3em; border-left: 1px solid #aaaaaa;  padding-left: 4px; }
+div.sourceCode
+  {  }
+@media screen {
+a.sourceLine::before { text-decoration: underline; }
+}
+code span.al { color: #ff0000; font-weight: bold; } /* Alert */
+code span.an { color: #60a0b0; font-weight: bold; font-style: italic; } /* Annotation */
+code span.at { color: #7d9029; } /* Attribute */
+code span.bn { color: #40a070; } /* BaseN */
+code span.bu { } /* BuiltIn */
+code span.cf { color: #007020; font-weight: bold; } /* ControlFlow */
+code span.ch { color: #4070a0; } /* Char */
+code span.cn { color: #880000; } /* Constant */
+code span.co { color: #60a0b0; font-style: italic; } /* Comment */
+code span.cv { color: #60a0b0; font-weight: bold; font-style: italic; } /* CommentVar */
+code span.do { color: #ba2121; font-style: italic; } /* Documentation */
+code span.dt { color: #902000; } /* DataType */
+code span.dv { color: #40a070; } /* DecVal */
+code span.er { color: #ff0000; font-weight: bold; } /* Error */
+code span.ex { } /* Extension */
+code span.fl { color: #40a070; } /* Float */
+code span.fu { color: #06287e; } /* Function */
+code span.im { } /* Import */
+code span.in { color: #60a0b0; font-weight: bold; font-style: italic; } /* Information */
+code span.kw { color: #007020; font-weight: bold; } /* Keyword */
+code span.op { color: #666666; } /* Operator */
+code span.ot { color: #007020; } /* Other */
+code span.pp { color: #bc7a00; } /* Preprocessor */
+code span.sc { color: #4070a0; } /* SpecialChar */
+code span.ss { color: #bb6688; } /* SpecialString */
+code span.st { color: #4070a0; } /* String */
+code span.va { color: #19177c; } /* Variable */
+code span.vs { color: #4070a0; } /* VerbatimString */
+code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warning */
+  </style>
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
 <h1 id="oleid">oleid</h1>
-<p>oleid is a script to analyze OLE files such as MS Office documents
-(e.g. Word, Excel), to detect specific characteristics usually found in
-malicious files (e.g. malware). For example it can detect VBA macros and
-embedded Flash objects.</p>
-<p>It is part of the <a
-href="http://www.decalage.info/python/oletools">python-oletools</a>
-package.</p>
+<p>oleid is a script to analyze OLE files such as MS Office documents (e.g. Word, Excel), to detect specific characteristics usually found in malicious files (e.g. malware). For example it can detect VBA macros and embedded Flash objects.</p>
+<p>It is part of the <a href="http://www.decalage.info/python/oletools">python-oletools</a> package.</p>
 <h2 id="main-features">Main Features</h2>
 <ul>
-<li>Detect OLE file type from its internal structure (e.g. MS Word,
-Excel, PowerPoint, …)</li>
+<li>Detect OLE file type from its internal structure (e.g. MS Word, Excel, PowerPoint, …)</li>
 <li>Detect VBA Macros</li>
 <li>Detect embedded Flash objects</li>
 <li>Detect embedded OLE objects</li>
@@ -245,8 +101,7 @@ Excel, PowerPoint, …)</li>
 <li>Generic VBA macros detection</li>
 <li>Detect auto-executable VBA macros</li>
 <li>Extended OLE file types detection</li>
-<li>Detect unusual OLE structures (fragmentation, unused sectors,
-etc)</li>
+<li>Detect unusual OLE structures (fragmentation, unused sectors, etc)</li>
 <li>Options to scan multiple files</li>
 <li>Options to scan files from encrypted zip archives</li>
 <li>CSV output</li>
@@ -254,8 +109,7 @@ etc)</li>
 <h2 id="usage">Usage</h2>
 <pre class="text"><code>oleid &lt;file&gt;</code></pre>
 <h3 id="example">Example</h3>
-<p>Analyzing a Word document containing a Flash object and VBA
-macros:</p>
+<p>Analyzing a Word document containing a Flash object and VBA macros:</p>
 <pre class="text"><code>C:\oletools&gt;oleid word_flash_vba.doc
 
 Filename: word_flash_vba.doc
@@ -274,45 +128,35 @@ Filename: word_flash_vba.doc
 | ObjectPool                    | True                  |
 | Flash objects                 | 1                     |
 +-------------------------------+-----------------------+</code></pre>
-<h2 id="how-to-use-oleid-in-your-python-applications">How to use oleid
-in your Python applications</h2>
-<p>First, import oletools.oleid, and create an <strong>OleID</strong>
-object to scan a file:</p>
-<div class="sourceCode" id="cb3"><pre
-class="sourceCode python"><code class="sourceCode python"><span id="cb3-1"><a href="#cb3-1" aria-hidden="true" tabindex="-1"></a><span class="im">import</span> oletools.oleid</span>
-<span id="cb3-2"><a href="#cb3-2" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb3-3"><a href="#cb3-3" aria-hidden="true" tabindex="-1"></a>oid <span class="op">=</span> oletools.oleid.OleID(filename)</span></code></pre></div>
-<p>Note: filename can be a filename, a file-like object, or a bytes
-string containing the file to be analyzed.</p>
-<p>Second, call the <strong>check()</strong> method. It returns a list
-of <strong>Indicator</strong> objects.</p>
+<h2 id="how-to-use-oleid-in-your-python-applications">How to use oleid in your Python applications</h2>
+<p>First, import oletools.oleid, and create an <strong>OleID</strong> object to scan a file:</p>
+<div class="sourceCode" id="cb3"><pre class="sourceCode python"><code class="sourceCode python"><a class="sourceLine" id="cb3-1" data-line-number="1"><span class="im">import</span> oletools.oleid</a>
+<a class="sourceLine" id="cb3-2" data-line-number="2"></a>
+<a class="sourceLine" id="cb3-3" data-line-number="3">oid <span class="op">=</span> oletools.oleid.OleID(filename)</a></code></pre></div>
+<p>Note: filename can be a filename, a file-like object, or a bytes string containing the file to be analyzed.</p>
+<p>Second, call the <strong>check()</strong> method. It returns a list of <strong>Indicator</strong> objects.</p>
 <p>Each Indicator object has the following attributes:</p>
 <ul>
 <li><strong>id</strong>: str, identifier for the indicator</li>
 <li><strong>name</strong>: str, name to display the indicator</li>
-<li><strong>description</strong>: str, long description of the
-indicator</li>
-<li><strong>type</strong>: class of the indicator (e.g. bool, str,
-int)</li>
+<li><strong>description</strong>: str, long description of the indicator</li>
+<li><strong>type</strong>: class of the indicator (e.g. bool, str, int)</li>
 <li><strong>value</strong>: value of the indicator</li>
 </ul>
 <p>For example, the following code displays all the indicators:</p>
-<div class="sourceCode" id="cb4"><pre
-class="sourceCode python"><code class="sourceCode python"><span id="cb4-1"><a href="#cb4-1" aria-hidden="true" tabindex="-1"></a>indicators <span class="op">=</span> oid.check()</span>
-<span id="cb4-2"><a href="#cb4-2" aria-hidden="true" tabindex="-1"></a><span class="cf">for</span> i <span class="kw">in</span> indicators:</span>
-<span id="cb4-3"><a href="#cb4-3" aria-hidden="true" tabindex="-1"></a>    <span class="bu">print</span> <span class="st">&#39;Indicator id=</span><span class="sc">%s</span><span class="st"> name=&quot;</span><span class="sc">%s</span><span class="st">&quot; type=</span><span class="sc">%s</span><span class="st"> value=</span><span class="sc">%s</span><span class="st">&#39;</span> <span class="op">%</span> (i.<span class="bu">id</span>, i.name, i.<span class="bu">type</span>, <span class="bu">repr</span>(i.value))</span>
-<span id="cb4-4"><a href="#cb4-4" aria-hidden="true" tabindex="-1"></a>    <span class="bu">print</span> <span class="st">&#39;description:&#39;</span>, i.description</span>
-<span id="cb4-5"><a href="#cb4-5" aria-hidden="true" tabindex="-1"></a>    <span class="bu">print</span> <span class="st">&#39;&#39;</span></span></code></pre></div>
+<div class="sourceCode" id="cb4"><pre class="sourceCode python"><code class="sourceCode python"><a class="sourceLine" id="cb4-1" data-line-number="1">indicators <span class="op">=</span> oid.check()</a>
+<a class="sourceLine" id="cb4-2" data-line-number="2"><span class="cf">for</span> i <span class="kw">in</span> indicators:</a>
+<a class="sourceLine" id="cb4-3" data-line-number="3">    <span class="bu">print</span> <span class="st">&#39;Indicator id=</span><span class="sc">%s</span><span class="st"> name=&quot;</span><span class="sc">%s</span><span class="st">&quot; type=</span><span class="sc">%s</span><span class="st"> value=</span><span class="sc">%s</span><span class="st">&#39;</span> <span class="op">%</span> (i.<span class="bu">id</span>, i.name, i.<span class="bu">type</span>, <span class="bu">repr</span>(i.value))</a>
+<a class="sourceLine" id="cb4-4" data-line-number="4">    <span class="bu">print</span> <span class="st">&#39;description:&#39;</span>, i.description</a>
+<a class="sourceLine" id="cb4-5" data-line-number="5">    <span class="bu">print</span> <span class="st">&#39;&#39;</span></a></code></pre></div>
 <p>See the source code of oleid.py for more details.</p>
 <hr />
-<h2 id="python-oletools-documentation">python-oletools
-documentation</h2>
+<h2 id="python-oletools-documentation">python-oletools documentation</h2>
 <ul>
 <li><a href="Home.html">Home</a></li>
 <li><a href="License.html">License</a></li>
 <li><a href="Install.html">Install</a></li>
-<li><a href="Contribute.html">Contribute</a>, Suggest Improvements or
-Report Issues</li>
+<li><a href="Contribute.html">Contribute</a>, Suggest Improvements or Report Issues</li>
 <li>Tools:
 <ul>
 <li><a href="mraptor.html">mraptor</a></li>

--- a/oletools/doc/olemap.html
+++ b/oletools/doc/olemap.html
@@ -4,166 +4,22 @@
   <meta charset="utf-8" />
   <meta name="generator" content="pandoc" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
-  <title>-</title>
-  <style>
-    html {
-      line-height: 1.5;
-      font-family: Georgia, serif;
-      font-size: 20px;
-      color: #1a1a1a;
-      background-color: #fdfdfd;
-    }
-    body {
-      margin: 0 auto;
-      max-width: 36em;
-      padding-left: 50px;
-      padding-right: 50px;
-      padding-top: 50px;
-      padding-bottom: 50px;
-      hyphens: auto;
-      overflow-wrap: break-word;
-      text-rendering: optimizeLegibility;
-      font-kerning: normal;
-    }
-    @media (max-width: 600px) {
-      body {
-        font-size: 0.9em;
-        padding: 1em;
-      }
-      h1 {
-        font-size: 1.8em;
-      }
-    }
-    @media print {
-      body {
-        background-color: transparent;
-        color: black;
-        font-size: 12pt;
-      }
-      p, h2, h3 {
-        orphans: 3;
-        widows: 3;
-      }
-      h2, h3, h4 {
-        page-break-after: avoid;
-      }
-    }
-    p {
-      margin: 1em 0;
-    }
-    a {
-      color: #1a1a1a;
-    }
-    a:visited {
-      color: #1a1a1a;
-    }
-    img {
-      max-width: 100%;
-    }
-    h1, h2, h3, h4, h5, h6 {
-      margin-top: 1.4em;
-    }
-    h5, h6 {
-      font-size: 1em;
-      font-style: italic;
-    }
-    h6 {
-      font-weight: normal;
-    }
-    ol, ul {
-      padding-left: 1.7em;
-      margin-top: 1em;
-    }
-    li > ol, li > ul {
-      margin-top: 0;
-    }
-    blockquote {
-      margin: 1em 0 1em 1.7em;
-      padding-left: 1em;
-      border-left: 2px solid #e6e6e6;
-      color: #606060;
-    }
-    code {
-      font-family: Menlo, Monaco, 'Lucida Console', Consolas, monospace;
-      font-size: 85%;
-      margin: 0;
-    }
-    pre {
-      margin: 1em 0;
-      overflow: auto;
-    }
-    pre code {
-      padding: 0;
-      overflow: visible;
-      overflow-wrap: normal;
-    }
-    .sourceCode {
-     background-color: transparent;
-     overflow: visible;
-    }
-    hr {
-      background-color: #1a1a1a;
-      border: none;
-      height: 1px;
-      margin: 1em 0;
-    }
-    table {
-      margin: 1em 0;
-      border-collapse: collapse;
-      width: 100%;
-      overflow-x: auto;
-      display: block;
-      font-variant-numeric: lining-nums tabular-nums;
-    }
-    table caption {
-      margin-bottom: 0.75em;
-    }
-    tbody {
-      margin-top: 0.5em;
-      border-top: 1px solid #1a1a1a;
-      border-bottom: 1px solid #1a1a1a;
-    }
-    th {
-      border-top: 1px solid #1a1a1a;
-      padding: 0.25em 0.5em 0.25em 0.5em;
-    }
-    td {
-      padding: 0.125em 0.5em 0.25em 0.5em;
-    }
-    header {
-      margin-bottom: 4em;
-      text-align: center;
-    }
-    #TOC li {
-      list-style: none;
-    }
-    #TOC ul {
-      padding-left: 1.3em;
-    }
-    #TOC > ul {
-      padding-left: 0;
-    }
-    #TOC a:not(:hover) {
-      text-decoration: none;
-    }
-    code{white-space: pre-wrap;}
-    span.smallcaps{font-variant: small-caps;}
-    span.underline{text-decoration: underline;}
-    div.column{display: inline-block; vertical-align: top; width: 50%;}
-    div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
-    ul.task-list{list-style: none;}
-    .display.math{display: block; text-align: center; margin: 0.5rem auto;}
+  <title>Untitled</title>
+  <style type="text/css">
+      code{white-space: pre-wrap;}
+      span.smallcaps{font-variant: small-caps;}
+      span.underline{text-decoration: underline;}
+      div.column{display: inline-block; vertical-align: top; width: 50%;}
   </style>
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
 <h1 id="olemap">olemap</h1>
-<p>olemap is a script to display a map of all the sectors in an OLE
-file.</p>
-<p>It can be used either as a command-line tool, or as a python module
-from your own applications.</p>
-<p>It is part of the <a
-href="http://www.decalage.info/python/oletools">python-oletools</a>
-package.</p>
+<p>olemap is a script to display a map of all the sectors in an OLE file.</p>
+<p>It can be used either as a command-line tool, or as a python module from your own applications.</p>
+<p>It is part of the <a href="http://www.decalage.info/python/oletools">python-oletools</a> package.</p>
 <h2 id="usage">Usage</h2>
 <pre class="text"><code>Usage: olemap &lt;filename&gt;</code></pre>
 <h3 id="examples">Examples</h3>
@@ -172,18 +28,15 @@ package.</p>
 <p><img src="olemap1.png" /></p>
 <p><img src="olemap2.png" /></p>
 <hr />
-<h2 id="how-to-use-olemap-in-python-applications">How to use olemap in
-Python applications</h2>
+<h2 id="how-to-use-olemap-in-python-applications">How to use olemap in Python applications</h2>
 <p>TODO</p>
 <hr />
-<h2 id="python-oletools-documentation">python-oletools
-documentation</h2>
+<h2 id="python-oletools-documentation">python-oletools documentation</h2>
 <ul>
 <li><a href="Home.html">Home</a></li>
 <li><a href="License.html">License</a></li>
 <li><a href="Install.html">Install</a></li>
-<li><a href="Contribute.html">Contribute</a>, Suggest Improvements or
-Report Issues</li>
+<li><a href="Contribute.html">Contribute</a>, Suggest Improvements or Report Issues</li>
 <li>Tools:
 <ul>
 <li><a href="mraptor.html">mraptor</a></li>

--- a/oletools/doc/olemeta.html
+++ b/oletools/doc/olemeta.html
@@ -4,181 +4,34 @@
   <meta charset="utf-8" />
   <meta name="generator" content="pandoc" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
-  <title>-</title>
-  <style>
-    html {
-      line-height: 1.5;
-      font-family: Georgia, serif;
-      font-size: 20px;
-      color: #1a1a1a;
-      background-color: #fdfdfd;
-    }
-    body {
-      margin: 0 auto;
-      max-width: 36em;
-      padding-left: 50px;
-      padding-right: 50px;
-      padding-top: 50px;
-      padding-bottom: 50px;
-      hyphens: auto;
-      overflow-wrap: break-word;
-      text-rendering: optimizeLegibility;
-      font-kerning: normal;
-    }
-    @media (max-width: 600px) {
-      body {
-        font-size: 0.9em;
-        padding: 1em;
-      }
-      h1 {
-        font-size: 1.8em;
-      }
-    }
-    @media print {
-      body {
-        background-color: transparent;
-        color: black;
-        font-size: 12pt;
-      }
-      p, h2, h3 {
-        orphans: 3;
-        widows: 3;
-      }
-      h2, h3, h4 {
-        page-break-after: avoid;
-      }
-    }
-    p {
-      margin: 1em 0;
-    }
-    a {
-      color: #1a1a1a;
-    }
-    a:visited {
-      color: #1a1a1a;
-    }
-    img {
-      max-width: 100%;
-    }
-    h1, h2, h3, h4, h5, h6 {
-      margin-top: 1.4em;
-    }
-    h5, h6 {
-      font-size: 1em;
-      font-style: italic;
-    }
-    h6 {
-      font-weight: normal;
-    }
-    ol, ul {
-      padding-left: 1.7em;
-      margin-top: 1em;
-    }
-    li > ol, li > ul {
-      margin-top: 0;
-    }
-    blockquote {
-      margin: 1em 0 1em 1.7em;
-      padding-left: 1em;
-      border-left: 2px solid #e6e6e6;
-      color: #606060;
-    }
-    code {
-      font-family: Menlo, Monaco, 'Lucida Console', Consolas, monospace;
-      font-size: 85%;
-      margin: 0;
-    }
-    pre {
-      margin: 1em 0;
-      overflow: auto;
-    }
-    pre code {
-      padding: 0;
-      overflow: visible;
-      overflow-wrap: normal;
-    }
-    .sourceCode {
-     background-color: transparent;
-     overflow: visible;
-    }
-    hr {
-      background-color: #1a1a1a;
-      border: none;
-      height: 1px;
-      margin: 1em 0;
-    }
-    table {
-      margin: 1em 0;
-      border-collapse: collapse;
-      width: 100%;
-      overflow-x: auto;
-      display: block;
-      font-variant-numeric: lining-nums tabular-nums;
-    }
-    table caption {
-      margin-bottom: 0.75em;
-    }
-    tbody {
-      margin-top: 0.5em;
-      border-top: 1px solid #1a1a1a;
-      border-bottom: 1px solid #1a1a1a;
-    }
-    th {
-      border-top: 1px solid #1a1a1a;
-      padding: 0.25em 0.5em 0.25em 0.5em;
-    }
-    td {
-      padding: 0.125em 0.5em 0.25em 0.5em;
-    }
-    header {
-      margin-bottom: 4em;
-      text-align: center;
-    }
-    #TOC li {
-      list-style: none;
-    }
-    #TOC ul {
-      padding-left: 1.3em;
-    }
-    #TOC > ul {
-      padding-left: 0;
-    }
-    #TOC a:not(:hover) {
-      text-decoration: none;
-    }
-    code{white-space: pre-wrap;}
-    span.smallcaps{font-variant: small-caps;}
-    span.underline{text-decoration: underline;}
-    div.column{display: inline-block; vertical-align: top; width: 50%;}
-    div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
-    ul.task-list{list-style: none;}
-    .display.math{display: block; text-align: center; margin: 0.5rem auto;}
+  <title>Untitled</title>
+  <style type="text/css">
+      code{white-space: pre-wrap;}
+      span.smallcaps{font-variant: small-caps;}
+      span.underline{text-decoration: underline;}
+      div.column{display: inline-block; vertical-align: top; width: 50%;}
   </style>
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
 <h1 id="olemeta">olemeta</h1>
-<p>olemeta is a script to parse OLE files such as MS Office documents
-(e.g. Word, Excel), to extract all standard properties present in the
-OLE file.</p>
-<p>It is part of the <a
-href="http://www.decalage.info/python/oletools">python-oletools</a>
-package.</p>
+<p>olemeta is a script to parse OLE files such as MS Office documents (e.g. Word, Excel), to extract all standard properties present in the OLE file.</p>
+<p>It is part of the <a href="http://www.decalage.info/python/oletools">python-oletools</a> package.</p>
 <h2 id="usage">Usage</h2>
 <pre class="text"><code>olemeta &lt;file&gt;</code></pre>
 <h3 id="example">Example</h3>
 <p><img src="olemeta1.png" /></p>
-<h2 id="how-to-use-olemeta-in-python-applications">How to use olemeta in
-Python applications</h2>
+<h2 id="how-to-use-olemeta-in-python-applications">How to use olemeta in Python applications</h2>
 <p>TODO</p>
 <hr />
-<h2 id="python-oletools-documentation">python-oletools
-documentation</h2>
+<h2 id="python-oletools-documentation">python-oletools documentation</h2>
 <ul>
 <li><a href="Home.html">Home</a></li>
 <li><a href="License.html">License</a></li>
 <li><a href="Install.html">Install</a></li>
-<li><a href="Contribute.html">Contribute</a>, Suggest Improvements or
-Report Issues</li>
+<li><a href="Contribute.html">Contribute</a>, Suggest Improvements or Report Issues</li>
 <li>Tools:
 <ul>
 <li><a href="mraptor.html">mraptor</a></li>

--- a/oletools/doc/oleobj.html
+++ b/oletools/doc/oleobj.html
@@ -4,181 +4,35 @@
   <meta charset="utf-8" />
   <meta name="generator" content="pandoc" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
-  <title>-</title>
-  <style>
-    html {
-      line-height: 1.5;
-      font-family: Georgia, serif;
-      font-size: 20px;
-      color: #1a1a1a;
-      background-color: #fdfdfd;
-    }
-    body {
-      margin: 0 auto;
-      max-width: 36em;
-      padding-left: 50px;
-      padding-right: 50px;
-      padding-top: 50px;
-      padding-bottom: 50px;
-      hyphens: auto;
-      overflow-wrap: break-word;
-      text-rendering: optimizeLegibility;
-      font-kerning: normal;
-    }
-    @media (max-width: 600px) {
-      body {
-        font-size: 0.9em;
-        padding: 1em;
-      }
-      h1 {
-        font-size: 1.8em;
-      }
-    }
-    @media print {
-      body {
-        background-color: transparent;
-        color: black;
-        font-size: 12pt;
-      }
-      p, h2, h3 {
-        orphans: 3;
-        widows: 3;
-      }
-      h2, h3, h4 {
-        page-break-after: avoid;
-      }
-    }
-    p {
-      margin: 1em 0;
-    }
-    a {
-      color: #1a1a1a;
-    }
-    a:visited {
-      color: #1a1a1a;
-    }
-    img {
-      max-width: 100%;
-    }
-    h1, h2, h3, h4, h5, h6 {
-      margin-top: 1.4em;
-    }
-    h5, h6 {
-      font-size: 1em;
-      font-style: italic;
-    }
-    h6 {
-      font-weight: normal;
-    }
-    ol, ul {
-      padding-left: 1.7em;
-      margin-top: 1em;
-    }
-    li > ol, li > ul {
-      margin-top: 0;
-    }
-    blockquote {
-      margin: 1em 0 1em 1.7em;
-      padding-left: 1em;
-      border-left: 2px solid #e6e6e6;
-      color: #606060;
-    }
-    code {
-      font-family: Menlo, Monaco, 'Lucida Console', Consolas, monospace;
-      font-size: 85%;
-      margin: 0;
-    }
-    pre {
-      margin: 1em 0;
-      overflow: auto;
-    }
-    pre code {
-      padding: 0;
-      overflow: visible;
-      overflow-wrap: normal;
-    }
-    .sourceCode {
-     background-color: transparent;
-     overflow: visible;
-    }
-    hr {
-      background-color: #1a1a1a;
-      border: none;
-      height: 1px;
-      margin: 1em 0;
-    }
-    table {
-      margin: 1em 0;
-      border-collapse: collapse;
-      width: 100%;
-      overflow-x: auto;
-      display: block;
-      font-variant-numeric: lining-nums tabular-nums;
-    }
-    table caption {
-      margin-bottom: 0.75em;
-    }
-    tbody {
-      margin-top: 0.5em;
-      border-top: 1px solid #1a1a1a;
-      border-bottom: 1px solid #1a1a1a;
-    }
-    th {
-      border-top: 1px solid #1a1a1a;
-      padding: 0.25em 0.5em 0.25em 0.5em;
-    }
-    td {
-      padding: 0.125em 0.5em 0.25em 0.5em;
-    }
-    header {
-      margin-bottom: 4em;
-      text-align: center;
-    }
-    #TOC li {
-      list-style: none;
-    }
-    #TOC ul {
-      padding-left: 1.3em;
-    }
-    #TOC > ul {
-      padding-left: 0;
-    }
-    #TOC a:not(:hover) {
-      text-decoration: none;
-    }
-    code{white-space: pre-wrap;}
-    span.smallcaps{font-variant: small-caps;}
-    span.underline{text-decoration: underline;}
-    div.column{display: inline-block; vertical-align: top; width: 50%;}
-    div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
-    ul.task-list{list-style: none;}
-    .display.math{display: block; text-align: center; margin: 0.5rem auto;}
+  <title>Untitled</title>
+  <style type="text/css">
+      code{white-space: pre-wrap;}
+      span.smallcaps{font-variant: small-caps;}
+      span.underline{text-decoration: underline;}
+      div.column{display: inline-block; vertical-align: top; width: 50%;}
   </style>
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
 <h1 id="oleobj">oleobj</h1>
 <p>oleobj is a script to extract embedded objects from OLE files.</p>
-<p>It can be used either as a command-line tool, or as a python module
-from your own applications.</p>
-<p>It is part of the <a
-href="http://www.decalage.info/python/oletools">python-oletools</a>
-package.</p>
+<p>It can be used either as a command-line tool, or as a python module from your own applications.</p>
+<p>It is part of the <a href="http://www.decalage.info/python/oletools">python-oletools</a> package.</p>
 <h2 id="usage">Usage</h2>
 <pre class="text"><code>TODO</code></pre>
 <hr />
-<h2 id="how-to-use-oleobj-in-python-applications">How to use oleobj in
-Python applications</h2>
+<h2 id="how-to-use-oleobj-in-python-applications">How to use oleobj in Python applications</h2>
 <p>See rtfobj.py source code.</p>
 <p>TODO</p>
 <hr />
-<h2 id="python-oletools-documentation">python-oletools
-documentation</h2>
+<h2 id="python-oletools-documentation">python-oletools documentation</h2>
 <ul>
 <li><a href="Home.html">Home</a></li>
 <li><a href="License.html">License</a></li>
 <li><a href="Install.html">Install</a></li>
-<li><a href="Contribute.html">Contribute</a>, Suggest Improvements or
-Report Issues</li>
+<li><a href="Contribute.html">Contribute</a>, Suggest Improvements or Report Issues</li>
 <li>Tools:
 <ul>
 <li><a href="mraptor.html">mraptor</a></li>

--- a/oletools/doc/oletimes.html
+++ b/oletools/doc/oletimes.html
@@ -4,170 +4,25 @@
   <meta charset="utf-8" />
   <meta name="generator" content="pandoc" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
-  <title>-</title>
-  <style>
-    html {
-      line-height: 1.5;
-      font-family: Georgia, serif;
-      font-size: 20px;
-      color: #1a1a1a;
-      background-color: #fdfdfd;
-    }
-    body {
-      margin: 0 auto;
-      max-width: 36em;
-      padding-left: 50px;
-      padding-right: 50px;
-      padding-top: 50px;
-      padding-bottom: 50px;
-      hyphens: auto;
-      overflow-wrap: break-word;
-      text-rendering: optimizeLegibility;
-      font-kerning: normal;
-    }
-    @media (max-width: 600px) {
-      body {
-        font-size: 0.9em;
-        padding: 1em;
-      }
-      h1 {
-        font-size: 1.8em;
-      }
-    }
-    @media print {
-      body {
-        background-color: transparent;
-        color: black;
-        font-size: 12pt;
-      }
-      p, h2, h3 {
-        orphans: 3;
-        widows: 3;
-      }
-      h2, h3, h4 {
-        page-break-after: avoid;
-      }
-    }
-    p {
-      margin: 1em 0;
-    }
-    a {
-      color: #1a1a1a;
-    }
-    a:visited {
-      color: #1a1a1a;
-    }
-    img {
-      max-width: 100%;
-    }
-    h1, h2, h3, h4, h5, h6 {
-      margin-top: 1.4em;
-    }
-    h5, h6 {
-      font-size: 1em;
-      font-style: italic;
-    }
-    h6 {
-      font-weight: normal;
-    }
-    ol, ul {
-      padding-left: 1.7em;
-      margin-top: 1em;
-    }
-    li > ol, li > ul {
-      margin-top: 0;
-    }
-    blockquote {
-      margin: 1em 0 1em 1.7em;
-      padding-left: 1em;
-      border-left: 2px solid #e6e6e6;
-      color: #606060;
-    }
-    code {
-      font-family: Menlo, Monaco, 'Lucida Console', Consolas, monospace;
-      font-size: 85%;
-      margin: 0;
-    }
-    pre {
-      margin: 1em 0;
-      overflow: auto;
-    }
-    pre code {
-      padding: 0;
-      overflow: visible;
-      overflow-wrap: normal;
-    }
-    .sourceCode {
-     background-color: transparent;
-     overflow: visible;
-    }
-    hr {
-      background-color: #1a1a1a;
-      border: none;
-      height: 1px;
-      margin: 1em 0;
-    }
-    table {
-      margin: 1em 0;
-      border-collapse: collapse;
-      width: 100%;
-      overflow-x: auto;
-      display: block;
-      font-variant-numeric: lining-nums tabular-nums;
-    }
-    table caption {
-      margin-bottom: 0.75em;
-    }
-    tbody {
-      margin-top: 0.5em;
-      border-top: 1px solid #1a1a1a;
-      border-bottom: 1px solid #1a1a1a;
-    }
-    th {
-      border-top: 1px solid #1a1a1a;
-      padding: 0.25em 0.5em 0.25em 0.5em;
-    }
-    td {
-      padding: 0.125em 0.5em 0.25em 0.5em;
-    }
-    header {
-      margin-bottom: 4em;
-      text-align: center;
-    }
-    #TOC li {
-      list-style: none;
-    }
-    #TOC ul {
-      padding-left: 1.3em;
-    }
-    #TOC > ul {
-      padding-left: 0;
-    }
-    #TOC a:not(:hover) {
-      text-decoration: none;
-    }
-    code{white-space: pre-wrap;}
-    span.smallcaps{font-variant: small-caps;}
-    span.underline{text-decoration: underline;}
-    div.column{display: inline-block; vertical-align: top; width: 50%;}
-    div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
-    ul.task-list{list-style: none;}
-    .display.math{display: block; text-align: center; margin: 0.5rem auto;}
+  <title>Untitled</title>
+  <style type="text/css">
+      code{white-space: pre-wrap;}
+      span.smallcaps{font-variant: small-caps;}
+      span.underline{text-decoration: underline;}
+      div.column{display: inline-block; vertical-align: top; width: 50%;}
   </style>
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
 <h1 id="oletimes">oletimes</h1>
-<p>oletimes is a script to parse OLE files such as MS Office documents
-(e.g. Word, Excel), to extract creation and modification times of all
-streams and storages in the OLE file.</p>
-<p>It is part of the <a
-href="http://www.decalage.info/python/oletools">python-oletools</a>
-package.</p>
+<p>oletimes is a script to parse OLE files such as MS Office documents (e.g. Word, Excel), to extract creation and modification times of all streams and storages in the OLE file.</p>
+<p>It is part of the <a href="http://www.decalage.info/python/oletools">python-oletools</a> package.</p>
 <h2 id="usage">Usage</h2>
 <pre class="text"><code>oletimes &lt;file&gt;</code></pre>
 <h3 id="example">Example</h3>
-<p>Checking the malware sample <a
-href="https://malwr.com/analysis/M2I4YWRhM2IwY2QwNDljN2E3ZWFjYTg3ODk4NmZhYmE/">DIAN_caso-5415.doc</a>:</p>
+<p>Checking the malware sample <a href="https://malwr.com/analysis/M2I4YWRhM2IwY2QwNDljN2E3ZWFjYTg3ODk4NmZhYmE/">DIAN_caso-5415.doc</a>:</p>
 <pre class="text"><code>&gt;oletimes DIAN_caso-5415.doc
 
 +----------------------------+---------------------+---------------------+
@@ -193,18 +48,15 @@ href="https://malwr.com/analysis/M2I4YWRhM2IwY2QwNDljN2E3ZWFjYTg3ODk4NmZhYmE/">D
 | &#39;Macros/VBA/dir&#39;           | None                | None                |
 | &#39;WordDocument&#39;             | None                | None                |
 +----------------------------+---------------------+---------------------+</code></pre>
-<h2 id="how-to-use-oletimes-in-python-applications">How to use oletimes
-in Python applications</h2>
+<h2 id="how-to-use-oletimes-in-python-applications">How to use oletimes in Python applications</h2>
 <p>TODO</p>
 <hr />
-<h2 id="python-oletools-documentation">python-oletools
-documentation</h2>
+<h2 id="python-oletools-documentation">python-oletools documentation</h2>
 <ul>
 <li><a href="Home.html">Home</a></li>
 <li><a href="License.html">License</a></li>
 <li><a href="Install.html">Install</a></li>
-<li><a href="Contribute.html">Contribute</a>, Suggest Improvements or
-Report Issues</li>
+<li><a href="Contribute.html">Contribute</a>, Suggest Improvements or Report Issues</li>
 <li>Tools:
 <ul>
 <li><a href="mraptor.html">mraptor</a></li>

--- a/oletools/doc/olevba.html
+++ b/oletools/doc/olevba.html
@@ -4,242 +4,88 @@
   <meta charset="utf-8" />
   <meta name="generator" content="pandoc" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
-  <title>-</title>
-  <style>
-    html {
-      line-height: 1.5;
-      font-family: Georgia, serif;
-      font-size: 20px;
-      color: #1a1a1a;
-      background-color: #fdfdfd;
-    }
-    body {
-      margin: 0 auto;
-      max-width: 36em;
-      padding-left: 50px;
-      padding-right: 50px;
-      padding-top: 50px;
-      padding-bottom: 50px;
-      hyphens: auto;
-      overflow-wrap: break-word;
-      text-rendering: optimizeLegibility;
-      font-kerning: normal;
-    }
-    @media (max-width: 600px) {
-      body {
-        font-size: 0.9em;
-        padding: 1em;
-      }
-      h1 {
-        font-size: 1.8em;
-      }
-    }
-    @media print {
-      body {
-        background-color: transparent;
-        color: black;
-        font-size: 12pt;
-      }
-      p, h2, h3 {
-        orphans: 3;
-        widows: 3;
-      }
-      h2, h3, h4 {
-        page-break-after: avoid;
-      }
-    }
-    p {
-      margin: 1em 0;
-    }
-    a {
-      color: #1a1a1a;
-    }
-    a:visited {
-      color: #1a1a1a;
-    }
-    img {
-      max-width: 100%;
-    }
-    h1, h2, h3, h4, h5, h6 {
-      margin-top: 1.4em;
-    }
-    h5, h6 {
-      font-size: 1em;
-      font-style: italic;
-    }
-    h6 {
-      font-weight: normal;
-    }
-    ol, ul {
-      padding-left: 1.7em;
-      margin-top: 1em;
-    }
-    li > ol, li > ul {
-      margin-top: 0;
-    }
-    blockquote {
-      margin: 1em 0 1em 1.7em;
-      padding-left: 1em;
-      border-left: 2px solid #e6e6e6;
-      color: #606060;
-    }
-    code {
-      font-family: Menlo, Monaco, 'Lucida Console', Consolas, monospace;
-      font-size: 85%;
-      margin: 0;
-    }
-    pre {
-      margin: 1em 0;
-      overflow: auto;
-    }
-    pre code {
-      padding: 0;
-      overflow: visible;
-      overflow-wrap: normal;
-    }
-    .sourceCode {
-     background-color: transparent;
-     overflow: visible;
-    }
-    hr {
-      background-color: #1a1a1a;
-      border: none;
-      height: 1px;
-      margin: 1em 0;
-    }
-    table {
-      margin: 1em 0;
-      border-collapse: collapse;
-      width: 100%;
-      overflow-x: auto;
-      display: block;
-      font-variant-numeric: lining-nums tabular-nums;
-    }
-    table caption {
-      margin-bottom: 0.75em;
-    }
-    tbody {
-      margin-top: 0.5em;
-      border-top: 1px solid #1a1a1a;
-      border-bottom: 1px solid #1a1a1a;
-    }
-    th {
-      border-top: 1px solid #1a1a1a;
-      padding: 0.25em 0.5em 0.25em 0.5em;
-    }
-    td {
-      padding: 0.125em 0.5em 0.25em 0.5em;
-    }
-    header {
-      margin-bottom: 4em;
-      text-align: center;
-    }
-    #TOC li {
-      list-style: none;
-    }
-    #TOC ul {
-      padding-left: 1.3em;
-    }
-    #TOC > ul {
-      padding-left: 0;
-    }
-    #TOC a:not(:hover) {
-      text-decoration: none;
-    }
-    code{white-space: pre-wrap;}
-    span.smallcaps{font-variant: small-caps;}
-    span.underline{text-decoration: underline;}
-    div.column{display: inline-block; vertical-align: top; width: 50%;}
-    div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
-    ul.task-list{list-style: none;}
-    pre > code.sourceCode { white-space: pre; position: relative; }
-    pre > code.sourceCode > span { display: inline-block; line-height: 1.25; }
-    pre > code.sourceCode > span:empty { height: 1.2em; }
-    .sourceCode { overflow: visible; }
-    code.sourceCode > span { color: inherit; text-decoration: inherit; }
-    div.sourceCode { margin: 1em 0; }
-    pre.sourceCode { margin: 0; }
-    @media screen {
-    div.sourceCode { overflow: auto; }
-    }
-    @media print {
-    pre > code.sourceCode { white-space: pre-wrap; }
-    pre > code.sourceCode > span { text-indent: -5em; padding-left: 5em; }
-    }
-    pre.numberSource code
-      { counter-reset: source-line 0; }
-    pre.numberSource code > span
-      { position: relative; left: -4em; counter-increment: source-line; }
-    pre.numberSource code > span > a:first-child::before
-      { content: counter(source-line);
-        position: relative; left: -1em; text-align: right; vertical-align: baseline;
-        border: none; display: inline-block;
-        -webkit-touch-callout: none; -webkit-user-select: none;
-        -khtml-user-select: none; -moz-user-select: none;
-        -ms-user-select: none; user-select: none;
-        padding: 0 4px; width: 4em;
-        color: #aaaaaa;
-      }
-    pre.numberSource { margin-left: 3em; border-left: 1px solid #aaaaaa;  padding-left: 4px; }
-    div.sourceCode
-      {   }
-    @media screen {
-    pre > code.sourceCode > span > a:first-child::before { text-decoration: underline; }
-    }
-    code span.al { color: #ff0000; font-weight: bold; } /* Alert */
-    code span.an { color: #60a0b0; font-weight: bold; font-style: italic; } /* Annotation */
-    code span.at { color: #7d9029; } /* Attribute */
-    code span.bn { color: #40a070; } /* BaseN */
-    code span.bu { color: #008000; } /* BuiltIn */
-    code span.cf { color: #007020; font-weight: bold; } /* ControlFlow */
-    code span.ch { color: #4070a0; } /* Char */
-    code span.cn { color: #880000; } /* Constant */
-    code span.co { color: #60a0b0; font-style: italic; } /* Comment */
-    code span.cv { color: #60a0b0; font-weight: bold; font-style: italic; } /* CommentVar */
-    code span.do { color: #ba2121; font-style: italic; } /* Documentation */
-    code span.dt { color: #902000; } /* DataType */
-    code span.dv { color: #40a070; } /* DecVal */
-    code span.er { color: #ff0000; font-weight: bold; } /* Error */
-    code span.ex { } /* Extension */
-    code span.fl { color: #40a070; } /* Float */
-    code span.fu { color: #06287e; } /* Function */
-    code span.im { color: #008000; font-weight: bold; } /* Import */
-    code span.in { color: #60a0b0; font-weight: bold; font-style: italic; } /* Information */
-    code span.kw { color: #007020; font-weight: bold; } /* Keyword */
-    code span.op { color: #666666; } /* Operator */
-    code span.ot { color: #007020; } /* Other */
-    code span.pp { color: #bc7a00; } /* Preprocessor */
-    code span.sc { color: #4070a0; } /* SpecialChar */
-    code span.ss { color: #bb6688; } /* SpecialString */
-    code span.st { color: #4070a0; } /* String */
-    code span.va { color: #19177c; } /* Variable */
-    code span.vs { color: #4070a0; } /* VerbatimString */
-    code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warning */
-    .display.math{display: block; text-align: center; margin: 0.5rem auto;}
+  <title>Untitled</title>
+  <style type="text/css">
+      code{white-space: pre-wrap;}
+      span.smallcaps{font-variant: small-caps;}
+      span.underline{text-decoration: underline;}
+      div.column{display: inline-block; vertical-align: top; width: 50%;}
   </style>
+  <style type="text/css">
+a.sourceLine { display: inline-block; line-height: 1.25; }
+a.sourceLine { pointer-events: none; color: inherit; text-decoration: inherit; }
+a.sourceLine:empty { height: 1.2em; position: absolute; }
+.sourceCode { overflow: visible; }
+code.sourceCode { white-space: pre; position: relative; }
+div.sourceCode { margin: 1em 0; }
+pre.sourceCode { margin: 0; }
+@media screen {
+div.sourceCode { overflow: auto; }
+}
+@media print {
+code.sourceCode { white-space: pre-wrap; }
+a.sourceLine { text-indent: -1em; padding-left: 1em; }
+}
+pre.numberSource a.sourceLine
+  { position: relative; }
+pre.numberSource a.sourceLine:empty
+  { position: absolute; }
+pre.numberSource a.sourceLine::before
+  { content: attr(data-line-number);
+    position: absolute; left: -5em; text-align: right; vertical-align: baseline;
+    border: none; pointer-events: all;
+    -webkit-touch-callout: none; -webkit-user-select: none;
+    -khtml-user-select: none; -moz-user-select: none;
+    -ms-user-select: none; user-select: none;
+    padding: 0 4px; width: 4em;
+    color: #aaaaaa;
+  }
+pre.numberSource { margin-left: 3em; border-left: 1px solid #aaaaaa;  padding-left: 4px; }
+div.sourceCode
+  {  }
+@media screen {
+a.sourceLine::before { text-decoration: underline; }
+}
+code span.al { color: #ff0000; font-weight: bold; } /* Alert */
+code span.an { color: #60a0b0; font-weight: bold; font-style: italic; } /* Annotation */
+code span.at { color: #7d9029; } /* Attribute */
+code span.bn { color: #40a070; } /* BaseN */
+code span.bu { } /* BuiltIn */
+code span.cf { color: #007020; font-weight: bold; } /* ControlFlow */
+code span.ch { color: #4070a0; } /* Char */
+code span.cn { color: #880000; } /* Constant */
+code span.co { color: #60a0b0; font-style: italic; } /* Comment */
+code span.cv { color: #60a0b0; font-weight: bold; font-style: italic; } /* CommentVar */
+code span.do { color: #ba2121; font-style: italic; } /* Documentation */
+code span.dt { color: #902000; } /* DataType */
+code span.dv { color: #40a070; } /* DecVal */
+code span.er { color: #ff0000; font-weight: bold; } /* Error */
+code span.ex { } /* Extension */
+code span.fl { color: #40a070; } /* Float */
+code span.fu { color: #06287e; } /* Function */
+code span.im { } /* Import */
+code span.in { color: #60a0b0; font-weight: bold; font-style: italic; } /* Information */
+code span.kw { color: #007020; font-weight: bold; } /* Keyword */
+code span.op { color: #666666; } /* Operator */
+code span.ot { color: #007020; } /* Other */
+code span.pp { color: #bc7a00; } /* Preprocessor */
+code span.sc { color: #4070a0; } /* SpecialChar */
+code span.ss { color: #bb6688; } /* SpecialString */
+code span.st { color: #4070a0; } /* String */
+code span.va { color: #19177c; } /* Variable */
+code span.vs { color: #4070a0; } /* VerbatimString */
+code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warning */
+  </style>
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
 <h1 id="olevba">olevba</h1>
-<p>olevba is a script to parse OLE and OpenXML files such as MS Office
-documents (e.g. Word, Excel), to <strong>detect VBA Macros</strong>,
-extract their <strong>source code</strong> in clear text, and detect
-security-related patterns such as <strong>auto-executable
-macros</strong>, <strong>suspicious VBA keywords</strong> used by
-malware, anti-sandboxing and anti-virtualization techniques, and
-potential <strong>IOCs</strong> (IP addresses, URLs, executable
-filenames, etc). It also detects and decodes several common
-<strong>obfuscation methods including Hex encoding, StrReverse, Base64,
-Dridex, VBA expressions</strong>, and extracts IOCs from decoded
-strings. XLM/Excel 4 Macros are also supported in Excel and SLK
-files.</p>
-<p>It can be used either as a command-line tool, or as a python module
-from your own applications.</p>
-<p>It is part of the <a
-href="http://www.decalage.info/python/oletools">python-oletools</a>
-package.</p>
-<p>olevba is based on source code from <a
-href="https://github.com/unixfreak0037/officeparser">officeparser</a> by
-John William Davison, with significant modifications.</p>
+<p>olevba is a script to parse OLE and OpenXML files such as MS Office documents (e.g. Word, Excel), to <strong>detect VBA Macros</strong>, extract their <strong>source code</strong> in clear text, and detect security-related patterns such as <strong>auto-executable macros</strong>, <strong>suspicious VBA keywords</strong> used by malware, anti-sandboxing and anti-virtualization techniques, and potential <strong>IOCs</strong> (IP addresses, URLs, executable filenames, etc). It also detects and decodes several common <strong>obfuscation methods including Hex encoding, StrReverse, Base64, Dridex, VBA expressions</strong>, and extracts IOCs from decoded strings. XLM/Excel 4 Macros are also supported in Excel and SLK files.</p>
+<p>It can be used either as a command-line tool, or as a python module from your own applications.</p>
+<p>It is part of the <a href="http://www.decalage.info/python/oletools">python-oletools</a> package.</p>
+<p>olevba is based on source code from <a href="https://github.com/unixfreak0037/officeparser">officeparser</a> by John William Davison, with significant modifications.</p>
 <h2 id="supported-formats">Supported formats</h2>
 <ul>
 <li>Word 97-2003 (.doc, .dot), Word 2007+ (.docm, .dotm)</li>
@@ -255,50 +101,31 @@ John William Davison, with significant modifications.</p>
 </ul>
 <p>S## Main Features</p>
 <ul>
-<li>Detect VBA macros in MS Office 97-2003 and 2007+ files, XML,
-MHT</li>
+<li>Detect VBA macros in MS Office 97-2003 and 2007+ files, XML, MHT</li>
 <li>Extract VBA macro source code</li>
 <li>Detect auto-executable macros</li>
 <li>Detect suspicious VBA keywords often used by malware</li>
 <li>Detect anti-sandboxing and anti-virtualization techniques</li>
-<li>Detect and decodes strings obfuscated with
-Hex/Base64/StrReverse/Dridex</li>
-<li>Deobfuscates VBA expressions with any combination of Chr, Asc, Val,
-StrReverse, Environ, +, &amp;, using a VBA parser built with <a
-href="http://pyparsing.wikispaces.com">pyparsing</a>, including custom
-Hex and Base64 encodings</li>
-<li>Extract IOCs/patterns of interest such as IP addresses, URLs, e-mail
-addresses and executable file names</li>
-<li>Scan multiple files and sample collections (wildcards,
-recursive)</li>
+<li>Detect and decodes strings obfuscated with Hex/Base64/StrReverse/Dridex</li>
+<li>Deobfuscates VBA expressions with any combination of Chr, Asc, Val, StrReverse, Environ, +, &amp;, using a VBA parser built with <a href="http://pyparsing.wikispaces.com">pyparsing</a>, including custom Hex and Base64 encodings</li>
+<li>Extract IOCs/patterns of interest such as IP addresses, URLs, e-mail addresses and executable file names</li>
+<li>Scan multiple files and sample collections (wildcards, recursive)</li>
 <li>Triage mode for a summary view of multiple files</li>
 <li>Scan malware samples in password-protected Zip archives</li>
 <li>Python API to use olevba from your applications</li>
 </ul>
-<p>MS Office files encrypted with a password are also supported, because
-VBA macro code is never encrypted, only the content of the document.</p>
+<p>MS Office files encrypted with a password are also supported, because VBA macro code is never encrypted, only the content of the document.</p>
 <h2 id="about-vba-macros">About VBA Macros</h2>
-<p>See <a href="http://www.decalage.info/en/vba_tools">this article</a>
-for more information and technical details about VBA Macros and how they
-are stored in MS Office documents.</p>
+<p>See <a href="http://www.decalage.info/en/vba_tools">this article</a> for more information and technical details about VBA Macros and how they are stored in MS Office documents.</p>
 <h2 id="how-it-works">How it works</h2>
 <ol type="1">
-<li>olevba checks the file type: If it is an OLE file (i.e MS Office
-97-2003), it is parsed right away.</li>
-<li>If it is a zip file (i.e. MS Office 2007+), XML or MHTML, olevba
-looks for all OLE files stored in it (e.g. vbaProject.bin,
-editdata.mso), and opens them.</li>
-<li>olevba identifies all the VBA projects stored in the OLE
-structure.</li>
-<li>Each VBA project is parsed to find the corresponding OLE streams
-containing macro code.</li>
-<li>In each of these OLE streams, the VBA macro source code is extracted
-and decompressed (RLE compression).</li>
-<li>olevba looks for specific strings obfuscated with various algorithms
-(Hex, Base64, StrReverse, Dridex, VBA expressions).</li>
-<li>olevba scans the macro source code and the deobfuscated strings to
-find suspicious keywords, auto-executable macros and potential IOCs
-(URLs, IP addresses, e-mail addresses, executable filenames, etc).</li>
+<li>olevba checks the file type: If it is an OLE file (i.e MS Office 97-2003), it is parsed right away.</li>
+<li>If it is a zip file (i.e. MS Office 2007+), XML or MHTML, olevba looks for all OLE files stored in it (e.g. vbaProject.bin, editdata.mso), and opens them.</li>
+<li>olevba identifies all the VBA projects stored in the OLE structure.</li>
+<li>Each VBA project is parsed to find the corresponding OLE streams containing macro code.</li>
+<li>In each of these OLE streams, the VBA macro source code is extracted and decompressed (RLE compression).</li>
+<li>olevba looks for specific strings obfuscated with various algorithms (Hex, Base64, StrReverse, Dridex, VBA expressions).</li>
+<li>olevba scans the macro source code and the deobfuscated strings to find suspicious keywords, auto-executable macros and potential IOCs (URLs, IP addresses, e-mail addresses, executable filenames, etc).</li>
 </ol>
 <h2 id="usage">Usage</h2>
 <pre class="text"><code>Usage: olevba [options] &lt;filename&gt; [filename2 ...]
@@ -337,37 +164,28 @@ Options:
     -d, --detailed      detailed mode, display full results (default for
                         single file)
     -j, --json          json mode, detailed in json format (never default)</code></pre>
-<p><strong>New in v0.54:</strong> the -p option can now be used to
-decrypt encrypted documents using the provided password(s).</p>
+<p><strong>New in v0.54:</strong> the -p option can now be used to decrypt encrypted documents using the provided password(s).</p>
 <h3 id="examples">Examples</h3>
 <p>Scan a single file:</p>
 <pre class="text"><code>olevba file.doc</code></pre>
-<p>Scan a single file, stored in a Zip archive with password
-“infected”:</p>
+<p>Scan a single file, stored in a Zip archive with password “infected”:</p>
 <pre class="text"><code>olevba malicious_file.xls.zip -z infected</code></pre>
 <p>Scan a single file, showing all obfuscated strings decoded:</p>
 <pre class="text"><code>olevba file.doc --decode</code></pre>
-<p>Scan a single file, showing the macro source code with VBA strings
-deobfuscated:</p>
+<p>Scan a single file, showing the macro source code with VBA strings deobfuscated:</p>
 <pre class="text"><code>olevba file.doc --reveal</code></pre>
 <p>Scan VBA source code extracted into a text file:</p>
 <pre class="text"><code>olevba source_code.vba</code></pre>
 <p>Scan a collection of files stored in a folder:</p>
 <pre class="text"><code>olevba &quot;MalwareZoo/VBA/*&quot;</code></pre>
-<p>NOTE: On Linux, MacOSX and other Unix variants, it is required to add
-double quotes around wildcards. Otherwise, they will be expanded by the
-shell instead of olevba.</p>
+<p>NOTE: On Linux, MacOSX and other Unix variants, it is required to add double quotes around wildcards. Otherwise, they will be expanded by the shell instead of olevba.</p>
 <p>Scan all .doc and .xls files, recursively in all subfolders:</p>
 <pre class="text"><code>olevba &quot;MalwareZoo/VBA/*.doc&quot; &quot;MalwareZoo/VBA/*.xls&quot; -r</code></pre>
-<p>Scan all .doc files within all .zip files with password,
-recursively:</p>
+<p>Scan all .doc files within all .zip files with password, recursively:</p>
 <pre class="text"><code>olevba &quot;MalwareZoo/VBA/*.zip&quot; -r -z infected -f &quot;*.doc&quot;</code></pre>
-<h3 id="detailed-analysis-mode-default-for-single-file">Detailed
-analysis mode (default for single file)</h3>
-<p>When a single file is scanned, or when using the option -d, all
-details of the analysis are displayed.</p>
-<p>For example, checking the malware sample <a
-href="https://malwr.com/analysis/M2I4YWRhM2IwY2QwNDljN2E3ZWFjYTg3ODk4NmZhYmE/">DIAN_caso-5415.doc</a>:</p>
+<h3 id="detailed-analysis-mode-default-for-single-file">Detailed analysis mode (default for single file)</h3>
+<p>When a single file is scanned, or when using the option -d, all details of the analysis are displayed.</p>
+<p>For example, checking the malware sample <a href="https://malwr.com/analysis/M2I4YWRhM2IwY2QwNDljN2E3ZWFjYTg3ODk4NmZhYmE/">DIAN_caso-5415.doc</a>:</p>
 <pre class="text"><code>&gt;olevba c:\MalwareZoo\VBA\DIAN_caso-5415.doc.zip -z infected
 ===============================================================================
 FILE: DIAN_caso-5415.doc.malware in c:\MalwareZoo\VBA\DIAN_caso-5415.doc.zip
@@ -419,32 +237,23 @@ ANALYSIS:
 | IOC        | test.exe             | Executable file name                    |
 | IOC        | sfjozjero.exe        | Executable file name                    |
 +------------+----------------------+-----------------------------------------+</code></pre>
-<h3 id="triage-mode-default-for-multiple-files">Triage mode (default for
-multiple files)</h3>
-<p>When several files are scanned, or when using the option -t, a
-summary of the analysis for each file is displayed. This is more
-convenient for quick triage of a collection of suspicious files.</p>
+<h3 id="triage-mode-default-for-multiple-files">Triage mode (default for multiple files)</h3>
+<p>When several files are scanned, or when using the option -t, a summary of the analysis for each file is displayed. This is more convenient for quick triage of a collection of suspicious files.</p>
 <p>The following flags show the results of the analysis:</p>
 <ul>
-<li><strong>OLE</strong>: the file type is OLE, for example MS Office
-97-2003</li>
-<li><strong>OpX</strong>: the file type is OpenXML, for example MS
-Office 2007+</li>
+<li><strong>OLE</strong>: the file type is OLE, for example MS Office 97-2003</li>
+<li><strong>OpX</strong>: the file type is OpenXML, for example MS Office 2007+</li>
 <li><strong>XML</strong>: the file type is Word 2003 XML</li>
-<li><strong>MHT</strong>: the file type is Word MHTML, aka Single File
-Web Page (.mht)</li>
+<li><strong>MHT</strong>: the file type is Word MHTML, aka Single File Web Page (.mht)</li>
 <li><strong>?</strong>: the file type is not supported</li>
 <li><strong>M</strong>: contains VBA Macros</li>
 <li><strong>A</strong>: auto-executable macros</li>
 <li><strong>S</strong>: suspicious VBA keywords</li>
 <li><strong>I</strong>: potential IOCs</li>
 <li><strong>H</strong>: hex-encoded strings (potential obfuscation)</li>
-<li><strong>B</strong>: Base64-encoded strings (potential
-obfuscation)</li>
-<li><strong>D</strong>: Dridex-encoded strings (potential
-obfuscation)</li>
-<li><strong>V</strong>: VBA string expressions (potential
-obfuscation)</li>
+<li><strong>B</strong>: Base64-encoded strings (potential obfuscation)</li>
+<li><strong>D</strong>: Dridex-encoded strings (potential obfuscation)</li>
+<li><strong>V</strong>: VBA string expressions (potential obfuscation)</li>
 </ul>
 <p>Here is an example:</p>
 <pre class="text"><code>c:\&gt;olevba \MalwareZoo\VBA\samples\*
@@ -467,253 +276,146 @@ OpX:MASI--- \MalwareZoo\VBA\samples\RottenKitten.xlsb.malware
 OLE:MASI-B- \MalwareZoo\VBA\samples\ROVNIX.doc.malware
 OLE:MA----- \MalwareZoo\VBA\samples\Word within Word macro auto.doc</code></pre>
 <h2 id="python-3-support---olevba3">Python 3 support - olevba3</h2>
-<p>Since v0.54, olevba is fully compatible with both Python 2 and 3.
-There is no need to use olevba3 anymore, however it is still present for
-backward compatibility.</p>
+<p>Since v0.54, olevba is fully compatible with both Python 2 and 3. There is no need to use olevba3 anymore, however it is still present for backward compatibility.</p>
 <hr />
-<h2 id="how-to-use-olevba-in-python-applications">How to use olevba in
-Python applications</h2>
-<p>olevba may be used to open a MS Office file, detect if it contains
-VBA macros, extract and analyze the VBA source code from your own python
-applications.</p>
-<p>IMPORTANT: olevba is currently under active development, therefore
-this API is likely to change.</p>
+<h2 id="how-to-use-olevba-in-python-applications">How to use olevba in Python applications</h2>
+<p>olevba may be used to open a MS Office file, detect if it contains VBA macros, extract and analyze the VBA source code from your own python applications.</p>
+<p>IMPORTANT: olevba is currently under active development, therefore this API is likely to change.</p>
 <h3 id="import-olevba">Import olevba</h3>
-<p>First, import the <strong>oletools.olevba</strong> package, using at
-least the VBA_Parser and VBA_Scanner classes:</p>
-<div class="sourceCode" id="cb12"><pre
-class="sourceCode python"><code class="sourceCode python"><span id="cb12-1"><a href="#cb12-1" aria-hidden="true" tabindex="-1"></a><span class="im">from</span> oletools.olevba <span class="im">import</span> VBA_Parser, TYPE_OLE, TYPE_OpenXML, TYPE_Word2003_XML, TYPE_MHTML</span></code></pre></div>
-<h3 id="parse-a-ms-office-file---vba_parser">Parse a MS Office file -
-VBA_Parser</h3>
-<p>To parse a file on disk, create an instance of the
-<strong>VBA_Parser</strong> class, providing the name of the file to
-open as parameter. For example:</p>
-<div class="sourceCode" id="cb13"><pre
-class="sourceCode python"><code class="sourceCode python"><span id="cb13-1"><a href="#cb13-1" aria-hidden="true" tabindex="-1"></a>vbaparser <span class="op">=</span> VBA_Parser(<span class="st">&#39;my_file_with_macros.doc&#39;</span>)</span></code></pre></div>
-<p>The file may also be provided as a bytes string containing its data.
-In that case, the actual filename must be provided for reference, and
-the file content with the data parameter. For example:</p>
-<div class="sourceCode" id="cb14"><pre
-class="sourceCode python"><code class="sourceCode python"><span id="cb14-1"><a href="#cb14-1" aria-hidden="true" tabindex="-1"></a>myfile <span class="op">=</span> <span class="st">&#39;my_file_with_macros.doc&#39;</span></span>
-<span id="cb14-2"><a href="#cb14-2" aria-hidden="true" tabindex="-1"></a>filedata <span class="op">=</span> <span class="bu">open</span>(myfile, <span class="st">&#39;rb&#39;</span>).read()</span>
-<span id="cb14-3"><a href="#cb14-3" aria-hidden="true" tabindex="-1"></a>vbaparser <span class="op">=</span> VBA_Parser(myfile, data<span class="op">=</span>filedata)</span></code></pre></div>
-<p>VBA_Parser will raise an exception if the file is not a supported
-format, such as OLE (MS Office 97-2003), OpenXML (MS Office 2007+),
-MHTML or Word 2003 XML.</p>
-<p>After parsing the file, the attribute
-<strong>VBA_Parser.type</strong> is a string indicating the file type.
-It can be either TYPE_OLE, TYPE_OpenXML, TYPE_Word2003_XML or
-TYPE_MHTML. (constants defined in the olevba module)</p>
+<p>First, import the <strong>oletools.olevba</strong> package, using at least the VBA_Parser and VBA_Scanner classes:</p>
+<div class="sourceCode" id="cb12"><pre class="sourceCode python"><code class="sourceCode python"><a class="sourceLine" id="cb12-1" data-line-number="1"><span class="im">from</span> oletools.olevba <span class="im">import</span> VBA_Parser, TYPE_OLE, TYPE_OpenXML, TYPE_Word2003_XML, TYPE_MHTML</a></code></pre></div>
+<h3 id="parse-a-ms-office-file---vba_parser">Parse a MS Office file - VBA_Parser</h3>
+<p>To parse a file on disk, create an instance of the <strong>VBA_Parser</strong> class, providing the name of the file to open as parameter. For example:</p>
+<div class="sourceCode" id="cb13"><pre class="sourceCode python"><code class="sourceCode python"><a class="sourceLine" id="cb13-1" data-line-number="1">vbaparser <span class="op">=</span> VBA_Parser(<span class="st">&#39;my_file_with_macros.doc&#39;</span>)</a></code></pre></div>
+<p>The file may also be provided as a bytes string containing its data. In that case, the actual filename must be provided for reference, and the file content with the data parameter. For example:</p>
+<div class="sourceCode" id="cb14"><pre class="sourceCode python"><code class="sourceCode python"><a class="sourceLine" id="cb14-1" data-line-number="1">myfile <span class="op">=</span> <span class="st">&#39;my_file_with_macros.doc&#39;</span></a>
+<a class="sourceLine" id="cb14-2" data-line-number="2">filedata <span class="op">=</span> <span class="bu">open</span>(myfile, <span class="st">&#39;rb&#39;</span>).read()</a>
+<a class="sourceLine" id="cb14-3" data-line-number="3">vbaparser <span class="op">=</span> VBA_Parser(myfile, data<span class="op">=</span>filedata)</a></code></pre></div>
+<p>VBA_Parser will raise an exception if the file is not a supported format, such as OLE (MS Office 97-2003), OpenXML (MS Office 2007+), MHTML or Word 2003 XML.</p>
+<p>After parsing the file, the attribute <strong>VBA_Parser.type</strong> is a string indicating the file type. It can be either TYPE_OLE, TYPE_OpenXML, TYPE_Word2003_XML or TYPE_MHTML. (constants defined in the olevba module)</p>
 <h3 id="detect-vba-macros">Detect VBA macros</h3>
-<p>The method <strong>detect_vba_macros</strong> of a VBA_Parser object
-returns True if VBA macros have been found in the file, False
-otherwise.</p>
-<div class="sourceCode" id="cb15"><pre
-class="sourceCode python"><code class="sourceCode python"><span id="cb15-1"><a href="#cb15-1" aria-hidden="true" tabindex="-1"></a><span class="cf">if</span> vbaparser.detect_vba_macros():</span>
-<span id="cb15-2"><a href="#cb15-2" aria-hidden="true" tabindex="-1"></a>    <span class="bu">print</span> <span class="st">&#39;VBA Macros found&#39;</span></span>
-<span id="cb15-3"><a href="#cb15-3" aria-hidden="true" tabindex="-1"></a><span class="cf">else</span>:</span>
-<span id="cb15-4"><a href="#cb15-4" aria-hidden="true" tabindex="-1"></a>    <span class="bu">print</span> <span class="st">&#39;No VBA Macros found&#39;</span></span></code></pre></div>
-<p>Note: The detection algorithm looks for streams and storage with
-specific names in the OLE structure, which works fine for all the
-supported formats listed above. However, for some formats such as
-PowerPoint 97-2003, this method will always return False because VBA
-Macros are stored in a different way which is not yet supported by
-olevba.</p>
-<p>Moreover, if the file contains an embedded document (e.g. an Excel
-workbook inserted into a Word document), this method may return True if
-the embedded document contains VBA Macros, even if the main document
-does not.</p>
-<h3 id="extract-vba-macro-source-code">Extract VBA Macro Source
-Code</h3>
-<p>The method <strong>extract_macros</strong> extracts and decompresses
-source code for each VBA macro found in the file (possibly including
-embedded files). It is a generator yielding a tuple (filename,
-stream_path, vba_filename, vba_code) for each VBA macro found.</p>
+<p>The method <strong>detect_vba_macros</strong> of a VBA_Parser object returns True if VBA macros have been found in the file, False otherwise.</p>
+<div class="sourceCode" id="cb15"><pre class="sourceCode python"><code class="sourceCode python"><a class="sourceLine" id="cb15-1" data-line-number="1"><span class="cf">if</span> vbaparser.detect_vba_macros():</a>
+<a class="sourceLine" id="cb15-2" data-line-number="2">    <span class="bu">print</span> <span class="st">&#39;VBA Macros found&#39;</span></a>
+<a class="sourceLine" id="cb15-3" data-line-number="3"><span class="cf">else</span>:</a>
+<a class="sourceLine" id="cb15-4" data-line-number="4">    <span class="bu">print</span> <span class="st">&#39;No VBA Macros found&#39;</span></a></code></pre></div>
+<p>Note: The detection algorithm looks for streams and storage with specific names in the OLE structure, which works fine for all the supported formats listed above. However, for some formats such as PowerPoint 97-2003, this method will always return False because VBA Macros are stored in a different way which is not yet supported by olevba.</p>
+<p>Moreover, if the file contains an embedded document (e.g. an Excel workbook inserted into a Word document), this method may return True if the embedded document contains VBA Macros, even if the main document does not.</p>
+<h3 id="extract-vba-macro-source-code">Extract VBA Macro Source Code</h3>
+<p>The method <strong>extract_macros</strong> extracts and decompresses source code for each VBA macro found in the file (possibly including embedded files). It is a generator yielding a tuple (filename, stream_path, vba_filename, vba_code) for each VBA macro found.</p>
 <ul>
-<li>filename: If the file is OLE (MS Office 97-2003), filename is the
-path of the file. If the file is OpenXML (MS Office 2007+), filename is
-the path of the OLE subfile containing VBA macros within the zip
-archive, e.g. word/vbaProject.bin.</li>
-<li>stream_path: path of the OLE stream containing the VBA macro source
-code</li>
+<li>filename: If the file is OLE (MS Office 97-2003), filename is the path of the file. If the file is OpenXML (MS Office 2007+), filename is the path of the OLE subfile containing VBA macros within the zip archive, e.g. word/vbaProject.bin.</li>
+<li>stream_path: path of the OLE stream containing the VBA macro source code</li>
 <li>vba_filename: corresponding VBA filename</li>
 <li>vba_code: string containing the VBA source code in clear text</li>
 </ul>
 <p>Example:</p>
-<div class="sourceCode" id="cb16"><pre
-class="sourceCode python"><code class="sourceCode python"><span id="cb16-1"><a href="#cb16-1" aria-hidden="true" tabindex="-1"></a><span class="cf">for</span> (filename, stream_path, vba_filename, vba_code) <span class="kw">in</span> vbaparser.extract_macros():</span>
-<span id="cb16-2"><a href="#cb16-2" aria-hidden="true" tabindex="-1"></a>    <span class="bu">print</span> <span class="st">&#39;-&#39;</span><span class="op">*</span><span class="dv">79</span></span>
-<span id="cb16-3"><a href="#cb16-3" aria-hidden="true" tabindex="-1"></a>    <span class="bu">print</span> <span class="st">&#39;Filename    :&#39;</span>, filename</span>
-<span id="cb16-4"><a href="#cb16-4" aria-hidden="true" tabindex="-1"></a>    <span class="bu">print</span> <span class="st">&#39;OLE stream  :&#39;</span>, stream_path</span>
-<span id="cb16-5"><a href="#cb16-5" aria-hidden="true" tabindex="-1"></a>    <span class="bu">print</span> <span class="st">&#39;VBA filename:&#39;</span>, vba_filename</span>
-<span id="cb16-6"><a href="#cb16-6" aria-hidden="true" tabindex="-1"></a>    <span class="bu">print</span> <span class="st">&#39;- &#39;</span><span class="op">*</span><span class="dv">39</span></span>
-<span id="cb16-7"><a href="#cb16-7" aria-hidden="true" tabindex="-1"></a>    <span class="bu">print</span> vba_code</span></code></pre></div>
-<p>Alternatively, the VBA_Parser method
-<strong>extract_all_macros</strong> returns the same results as a list
-of tuples.</p>
+<div class="sourceCode" id="cb16"><pre class="sourceCode python"><code class="sourceCode python"><a class="sourceLine" id="cb16-1" data-line-number="1"><span class="cf">for</span> (filename, stream_path, vba_filename, vba_code) <span class="kw">in</span> vbaparser.extract_macros():</a>
+<a class="sourceLine" id="cb16-2" data-line-number="2">    <span class="bu">print</span> <span class="st">&#39;-&#39;</span><span class="op">*</span><span class="dv">79</span></a>
+<a class="sourceLine" id="cb16-3" data-line-number="3">    <span class="bu">print</span> <span class="st">&#39;Filename    :&#39;</span>, filename</a>
+<a class="sourceLine" id="cb16-4" data-line-number="4">    <span class="bu">print</span> <span class="st">&#39;OLE stream  :&#39;</span>, stream_path</a>
+<a class="sourceLine" id="cb16-5" data-line-number="5">    <span class="bu">print</span> <span class="st">&#39;VBA filename:&#39;</span>, vba_filename</a>
+<a class="sourceLine" id="cb16-6" data-line-number="6">    <span class="bu">print</span> <span class="st">&#39;- &#39;</span><span class="op">*</span><span class="dv">39</span></a>
+<a class="sourceLine" id="cb16-7" data-line-number="7">    <span class="bu">print</span> vba_code</a></code></pre></div>
+<p>Alternatively, the VBA_Parser method <strong>extract_all_macros</strong> returns the same results as a list of tuples.</p>
 <h3 id="analyze-vba-source-code">Analyze VBA Source Code</h3>
-<p>Since version 0.40, the VBA_Parser class provides simpler methods
-than VBA_Scanner to analyze all macros contained in a file:</p>
-<p>The method <strong>analyze_macros</strong> from the class
-<strong>VBA_Parser</strong> can be used to scan the source code of all
-VBA modules to find obfuscated strings, suspicious keywords, IOCs,
-auto-executable macros, etc.</p>
-<p>analyze_macros() takes an optional argument show_decoded_strings: if
-set to True, the results will contain all the encoded strings found in
-the code (Hex, Base64, Dridex) with their decoded value. By default, it
-will only include the strings which contain printable characters.</p>
-<p><strong>VBA_Parser.analyze_macros()</strong> returns a list of tuples
-(type, keyword, description), one for each item in the results.</p>
+<p>Since version 0.40, the VBA_Parser class provides simpler methods than VBA_Scanner to analyze all macros contained in a file:</p>
+<p>The method <strong>analyze_macros</strong> from the class <strong>VBA_Parser</strong> can be used to scan the source code of all VBA modules to find obfuscated strings, suspicious keywords, IOCs, auto-executable macros, etc.</p>
+<p>analyze_macros() takes an optional argument show_decoded_strings: if set to True, the results will contain all the encoded strings found in the code (Hex, Base64, Dridex) with their decoded value. By default, it will only include the strings which contain printable characters.</p>
+<p><strong>VBA_Parser.analyze_macros()</strong> returns a list of tuples (type, keyword, description), one for each item in the results.</p>
 <ul>
-<li>type may be either ‘AutoExec’, ‘Suspicious’, ‘IOC’, ‘Hex String’,
-‘Base64 String’, ‘Dridex String’ or ‘VBA obfuscated Strings’.</li>
-<li>keyword is the string found for auto-executable macros, suspicious
-keywords or IOCs. For obfuscated strings, it is the decoded value of the
-string.</li>
-<li>description provides a description of the keyword. For obfuscated
-strings, it is the encoded value of the string.</li>
+<li>type may be either ‘AutoExec’, ‘Suspicious’, ‘IOC’, ‘Hex String’, ‘Base64 String’, ‘Dridex String’ or ‘VBA obfuscated Strings’.</li>
+<li>keyword is the string found for auto-executable macros, suspicious keywords or IOCs. For obfuscated strings, it is the decoded value of the string.</li>
+<li>description provides a description of the keyword. For obfuscated strings, it is the encoded value of the string.</li>
 </ul>
 <p>Example:</p>
-<div class="sourceCode" id="cb17"><pre
-class="sourceCode python"><code class="sourceCode python"><span id="cb17-1"><a href="#cb17-1" aria-hidden="true" tabindex="-1"></a>results <span class="op">=</span> vbaparser.analyze_macros()</span>
-<span id="cb17-2"><a href="#cb17-2" aria-hidden="true" tabindex="-1"></a><span class="cf">for</span> kw_type, keyword, description <span class="kw">in</span> results:</span>
-<span id="cb17-3"><a href="#cb17-3" aria-hidden="true" tabindex="-1"></a>    <span class="bu">print</span> <span class="st">&#39;type=</span><span class="sc">%s</span><span class="st"> - keyword=</span><span class="sc">%s</span><span class="st"> - description=</span><span class="sc">%s</span><span class="st">&#39;</span> <span class="op">%</span> (kw_type, keyword, description)</span></code></pre></div>
-<p>After calling analyze_macros, the following VBA_Parser attributes
-also provide the number of items found for each category:</p>
-<div class="sourceCode" id="cb18"><pre
-class="sourceCode python"><code class="sourceCode python"><span id="cb18-1"><a href="#cb18-1" aria-hidden="true" tabindex="-1"></a><span class="bu">print</span> <span class="st">&#39;AutoExec keywords: </span><span class="sc">%d</span><span class="st">&#39;</span> <span class="op">%</span> vbaparser.nb_autoexec</span>
-<span id="cb18-2"><a href="#cb18-2" aria-hidden="true" tabindex="-1"></a><span class="bu">print</span> <span class="st">&#39;Suspicious keywords: </span><span class="sc">%d</span><span class="st">&#39;</span> <span class="op">%</span> vbaparser.nb_suspicious</span>
-<span id="cb18-3"><a href="#cb18-3" aria-hidden="true" tabindex="-1"></a><span class="bu">print</span> <span class="st">&#39;IOCs: </span><span class="sc">%d</span><span class="st">&#39;</span> <span class="op">%</span> vbaparser.nb_iocs</span>
-<span id="cb18-4"><a href="#cb18-4" aria-hidden="true" tabindex="-1"></a><span class="bu">print</span> <span class="st">&#39;Hex obfuscated strings: </span><span class="sc">%d</span><span class="st">&#39;</span> <span class="op">%</span> vbaparser.nb_hexstrings</span>
-<span id="cb18-5"><a href="#cb18-5" aria-hidden="true" tabindex="-1"></a><span class="bu">print</span> <span class="st">&#39;Base64 obfuscated strings: </span><span class="sc">%d</span><span class="st">&#39;</span> <span class="op">%</span> vbaparser.nb_base64strings</span>
-<span id="cb18-6"><a href="#cb18-6" aria-hidden="true" tabindex="-1"></a><span class="bu">print</span> <span class="st">&#39;Dridex obfuscated strings: </span><span class="sc">%d</span><span class="st">&#39;</span> <span class="op">%</span> vbaparser.nb_dridexstrings</span>
-<span id="cb18-7"><a href="#cb18-7" aria-hidden="true" tabindex="-1"></a><span class="bu">print</span> <span class="st">&#39;VBA obfuscated strings: </span><span class="sc">%d</span><span class="st">&#39;</span> <span class="op">%</span> vbaparser.nb_vbastrings</span></code></pre></div>
-<h3 id="deobfuscate-vba-macro-source-code">Deobfuscate VBA Macro Source
-Code</h3>
-<p>The method <strong>reveal</strong> attempts to deobfuscate the macro
-source code by replacing all the obfuscated strings by their decoded
-content. Returns a single string.</p>
+<div class="sourceCode" id="cb17"><pre class="sourceCode python"><code class="sourceCode python"><a class="sourceLine" id="cb17-1" data-line-number="1">results <span class="op">=</span> vbaparser.analyze_macros()</a>
+<a class="sourceLine" id="cb17-2" data-line-number="2"><span class="cf">for</span> kw_type, keyword, description <span class="kw">in</span> results:</a>
+<a class="sourceLine" id="cb17-3" data-line-number="3">    <span class="bu">print</span> <span class="st">&#39;type=</span><span class="sc">%s</span><span class="st"> - keyword=</span><span class="sc">%s</span><span class="st"> - description=</span><span class="sc">%s</span><span class="st">&#39;</span> <span class="op">%</span> (kw_type, keyword, description)</a></code></pre></div>
+<p>After calling analyze_macros, the following VBA_Parser attributes also provide the number of items found for each category:</p>
+<div class="sourceCode" id="cb18"><pre class="sourceCode python"><code class="sourceCode python"><a class="sourceLine" id="cb18-1" data-line-number="1"><span class="bu">print</span> <span class="st">&#39;AutoExec keywords: </span><span class="sc">%d</span><span class="st">&#39;</span> <span class="op">%</span> vbaparser.nb_autoexec</a>
+<a class="sourceLine" id="cb18-2" data-line-number="2"><span class="bu">print</span> <span class="st">&#39;Suspicious keywords: </span><span class="sc">%d</span><span class="st">&#39;</span> <span class="op">%</span> vbaparser.nb_suspicious</a>
+<a class="sourceLine" id="cb18-3" data-line-number="3"><span class="bu">print</span> <span class="st">&#39;IOCs: </span><span class="sc">%d</span><span class="st">&#39;</span> <span class="op">%</span> vbaparser.nb_iocs</a>
+<a class="sourceLine" id="cb18-4" data-line-number="4"><span class="bu">print</span> <span class="st">&#39;Hex obfuscated strings: </span><span class="sc">%d</span><span class="st">&#39;</span> <span class="op">%</span> vbaparser.nb_hexstrings</a>
+<a class="sourceLine" id="cb18-5" data-line-number="5"><span class="bu">print</span> <span class="st">&#39;Base64 obfuscated strings: </span><span class="sc">%d</span><span class="st">&#39;</span> <span class="op">%</span> vbaparser.nb_base64strings</a>
+<a class="sourceLine" id="cb18-6" data-line-number="6"><span class="bu">print</span> <span class="st">&#39;Dridex obfuscated strings: </span><span class="sc">%d</span><span class="st">&#39;</span> <span class="op">%</span> vbaparser.nb_dridexstrings</a>
+<a class="sourceLine" id="cb18-7" data-line-number="7"><span class="bu">print</span> <span class="st">&#39;VBA obfuscated strings: </span><span class="sc">%d</span><span class="st">&#39;</span> <span class="op">%</span> vbaparser.nb_vbastrings</a></code></pre></div>
+<h3 id="deobfuscate-vba-macro-source-code">Deobfuscate VBA Macro Source Code</h3>
+<p>The method <strong>reveal</strong> attempts to deobfuscate the macro source code by replacing all the obfuscated strings by their decoded content. Returns a single string.</p>
 <p>Example:</p>
-<div class="sourceCode" id="cb19"><pre
-class="sourceCode python"><code class="sourceCode python"><span id="cb19-1"><a href="#cb19-1" aria-hidden="true" tabindex="-1"></a><span class="bu">print</span> vbaparser.reveal()</span></code></pre></div>
+<div class="sourceCode" id="cb19"><pre class="sourceCode python"><code class="sourceCode python"><a class="sourceLine" id="cb19-1" data-line-number="1"><span class="bu">print</span> vbaparser.reveal()</a></code></pre></div>
 <h3 id="close-the-vba_parser">Close the VBA_Parser</h3>
-<p>After usage, it is better to call the <strong>close</strong> method
-of the VBA_Parser object, to make sure the file is closed, especially if
-your application is parsing many files.</p>
-<div class="sourceCode" id="cb20"><pre
-class="sourceCode python"><code class="sourceCode python"><span id="cb20-1"><a href="#cb20-1" aria-hidden="true" tabindex="-1"></a>vbaparser.close()</span></code></pre></div>
+<p>After usage, it is better to call the <strong>close</strong> method of the VBA_Parser object, to make sure the file is closed, especially if your application is parsing many files.</p>
+<div class="sourceCode" id="cb20"><pre class="sourceCode python"><code class="sourceCode python"><a class="sourceLine" id="cb20-1" data-line-number="1">vbaparser.close()</a></code></pre></div>
 <hr />
 <h2 id="deprecated-api">Deprecated API</h2>
-<p>The following methods and functions are still functional, but their
-usage is not recommended since they have been replaced by better
-solutions.</p>
+<p>The following methods and functions are still functional, but their usage is not recommended since they have been replaced by better solutions.</p>
 <h3 id="vba_scanner-deprecated">VBA_Scanner (deprecated)</h3>
-<p>The class <strong>VBA_Scanner</strong> can be used to scan the source
-code of a VBA module to find obfuscated strings, suspicious keywords,
-IOCs, auto-executable macros, etc.</p>
-<p>First, create a VBA_Scanner object with a string containing the VBA
-source code (for example returned by the extract_macros method). Then
-call the methods <strong>scan</strong> or <strong>scan_summary</strong>
-to get the results of the analysis.</p>
-<p>scan() takes an optional argument include_decoded_strings: if set to
-True, the results will contain all the encoded strings found in the code
-(Hex, Base64, Dridex) with their decoded value.</p>
-<p><strong>scan</strong> returns a list of tuples (type, keyword,
-description), one for each item in the results.</p>
+<p>The class <strong>VBA_Scanner</strong> can be used to scan the source code of a VBA module to find obfuscated strings, suspicious keywords, IOCs, auto-executable macros, etc.</p>
+<p>First, create a VBA_Scanner object with a string containing the VBA source code (for example returned by the extract_macros method). Then call the methods <strong>scan</strong> or <strong>scan_summary</strong> to get the results of the analysis.</p>
+<p>scan() takes an optional argument include_decoded_strings: if set to True, the results will contain all the encoded strings found in the code (Hex, Base64, Dridex) with their decoded value.</p>
+<p><strong>scan</strong> returns a list of tuples (type, keyword, description), one for each item in the results.</p>
 <ul>
-<li>type may be either ‘AutoExec’, ‘Suspicious’, ‘IOC’, ‘Hex String’,
-‘Base64 String’ or ‘Dridex String’.</li>
-<li>keyword is the string found for auto-executable macros, suspicious
-keywords or IOCs. For obfuscated strings, it is the decoded value of the
-string.</li>
-<li>description provides a description of the keyword. For obfuscated
-strings, it is the encoded value of the string.</li>
+<li>type may be either ‘AutoExec’, ‘Suspicious’, ‘IOC’, ‘Hex String’, ‘Base64 String’ or ‘Dridex String’.</li>
+<li>keyword is the string found for auto-executable macros, suspicious keywords or IOCs. For obfuscated strings, it is the decoded value of the string.</li>
+<li>description provides a description of the keyword. For obfuscated strings, it is the encoded value of the string.</li>
 </ul>
 <p>Example:</p>
-<div class="sourceCode" id="cb21"><pre
-class="sourceCode python"><code class="sourceCode python"><span id="cb21-1"><a href="#cb21-1" aria-hidden="true" tabindex="-1"></a>vba_scanner <span class="op">=</span> VBA_Scanner(vba_code)</span>
-<span id="cb21-2"><a href="#cb21-2" aria-hidden="true" tabindex="-1"></a>results <span class="op">=</span> vba_scanner.scan(include_decoded_strings<span class="op">=</span><span class="va">True</span>)</span>
-<span id="cb21-3"><a href="#cb21-3" aria-hidden="true" tabindex="-1"></a><span class="cf">for</span> kw_type, keyword, description <span class="kw">in</span> results:</span>
-<span id="cb21-4"><a href="#cb21-4" aria-hidden="true" tabindex="-1"></a>    <span class="bu">print</span> <span class="st">&#39;type=</span><span class="sc">%s</span><span class="st"> - keyword=</span><span class="sc">%s</span><span class="st"> - description=</span><span class="sc">%s</span><span class="st">&#39;</span> <span class="op">%</span> (kw_type, keyword, description)</span></code></pre></div>
-<p>The function <strong>scan_vba</strong> is a shortcut for
-VBA_Scanner(vba_code).scan():</p>
-<div class="sourceCode" id="cb22"><pre
-class="sourceCode python"><code class="sourceCode python"><span id="cb22-1"><a href="#cb22-1" aria-hidden="true" tabindex="-1"></a>results <span class="op">=</span> scan_vba(vba_code, include_decoded_strings<span class="op">=</span><span class="va">True</span>)</span>
-<span id="cb22-2"><a href="#cb22-2" aria-hidden="true" tabindex="-1"></a><span class="cf">for</span> kw_type, keyword, description <span class="kw">in</span> results:</span>
-<span id="cb22-3"><a href="#cb22-3" aria-hidden="true" tabindex="-1"></a>    <span class="bu">print</span> <span class="st">&#39;type=</span><span class="sc">%s</span><span class="st"> - keyword=</span><span class="sc">%s</span><span class="st"> - description=</span><span class="sc">%s</span><span class="st">&#39;</span> <span class="op">%</span> (kw_type, keyword, description)</span></code></pre></div>
-<p><strong>scan_summary</strong> returns a tuple with the number of
-items found for each category: (autoexec, suspicious, IOCs, hex, base64,
-dridex).</p>
-<h3 id="detect-auto-executable-macros-deprecated">Detect auto-executable
-macros (deprecated)</h3>
-<p><strong>Deprecated</strong>: It is preferable to use either scan_vba
-or VBA_Scanner to get all results at once.</p>
-<p>The function <strong>detect_autoexec</strong> checks if VBA macro
-code contains specific macro names that will be triggered when the
-document/workbook is opened, closed, changed, etc.</p>
-<p>It returns a list of tuples containing two strings, the detected
-keyword, and the description of the trigger. (See the malware example
-above)</p>
+<div class="sourceCode" id="cb21"><pre class="sourceCode python"><code class="sourceCode python"><a class="sourceLine" id="cb21-1" data-line-number="1">vba_scanner <span class="op">=</span> VBA_Scanner(vba_code)</a>
+<a class="sourceLine" id="cb21-2" data-line-number="2">results <span class="op">=</span> vba_scanner.scan(include_decoded_strings<span class="op">=</span><span class="va">True</span>)</a>
+<a class="sourceLine" id="cb21-3" data-line-number="3"><span class="cf">for</span> kw_type, keyword, description <span class="kw">in</span> results:</a>
+<a class="sourceLine" id="cb21-4" data-line-number="4">    <span class="bu">print</span> <span class="st">&#39;type=</span><span class="sc">%s</span><span class="st"> - keyword=</span><span class="sc">%s</span><span class="st"> - description=</span><span class="sc">%s</span><span class="st">&#39;</span> <span class="op">%</span> (kw_type, keyword, description)</a></code></pre></div>
+<p>The function <strong>scan_vba</strong> is a shortcut for VBA_Scanner(vba_code).scan():</p>
+<div class="sourceCode" id="cb22"><pre class="sourceCode python"><code class="sourceCode python"><a class="sourceLine" id="cb22-1" data-line-number="1">results <span class="op">=</span> scan_vba(vba_code, include_decoded_strings<span class="op">=</span><span class="va">True</span>)</a>
+<a class="sourceLine" id="cb22-2" data-line-number="2"><span class="cf">for</span> kw_type, keyword, description <span class="kw">in</span> results:</a>
+<a class="sourceLine" id="cb22-3" data-line-number="3">    <span class="bu">print</span> <span class="st">&#39;type=</span><span class="sc">%s</span><span class="st"> - keyword=</span><span class="sc">%s</span><span class="st"> - description=</span><span class="sc">%s</span><span class="st">&#39;</span> <span class="op">%</span> (kw_type, keyword, description)</a></code></pre></div>
+<p><strong>scan_summary</strong> returns a tuple with the number of items found for each category: (autoexec, suspicious, IOCs, hex, base64, dridex).</p>
+<h3 id="detect-auto-executable-macros-deprecated">Detect auto-executable macros (deprecated)</h3>
+<p><strong>Deprecated</strong>: It is preferable to use either scan_vba or VBA_Scanner to get all results at once.</p>
+<p>The function <strong>detect_autoexec</strong> checks if VBA macro code contains specific macro names that will be triggered when the document/workbook is opened, closed, changed, etc.</p>
+<p>It returns a list of tuples containing two strings, the detected keyword, and the description of the trigger. (See the malware example above)</p>
 <p>Sample usage:</p>
-<div class="sourceCode" id="cb23"><pre
-class="sourceCode python"><code class="sourceCode python"><span id="cb23-1"><a href="#cb23-1" aria-hidden="true" tabindex="-1"></a><span class="im">from</span> oletools.olevba <span class="im">import</span> detect_autoexec</span>
-<span id="cb23-2"><a href="#cb23-2" aria-hidden="true" tabindex="-1"></a>autoexec_keywords <span class="op">=</span> detect_autoexec(vba_code)</span>
-<span id="cb23-3"><a href="#cb23-3" aria-hidden="true" tabindex="-1"></a><span class="cf">if</span> autoexec_keywords:</span>
-<span id="cb23-4"><a href="#cb23-4" aria-hidden="true" tabindex="-1"></a>    <span class="bu">print</span> <span class="st">&#39;Auto-executable macro keywords found:&#39;</span></span>
-<span id="cb23-5"><a href="#cb23-5" aria-hidden="true" tabindex="-1"></a>    <span class="cf">for</span> keyword, description <span class="kw">in</span> autoexec_keywords:</span>
-<span id="cb23-6"><a href="#cb23-6" aria-hidden="true" tabindex="-1"></a>        <span class="bu">print</span> <span class="st">&#39;</span><span class="sc">%s</span><span class="st">: </span><span class="sc">%s</span><span class="st">&#39;</span> <span class="op">%</span> (keyword, description)</span>
-<span id="cb23-7"><a href="#cb23-7" aria-hidden="true" tabindex="-1"></a><span class="cf">else</span>:</span>
-<span id="cb23-8"><a href="#cb23-8" aria-hidden="true" tabindex="-1"></a>    <span class="bu">print</span> <span class="st">&#39;Auto-executable macro keywords: None found&#39;</span></span></code></pre></div>
-<h3 id="detect-suspicious-vba-keywords-deprecated">Detect suspicious VBA
-keywords (deprecated)</h3>
-<p><strong>Deprecated</strong>: It is preferable to use either scan_vba
-or VBA_Scanner to get all results at once.</p>
-<p>The function <strong>detect_suspicious</strong> checks if VBA macro
-code contains specific keywords often used by malware to act on the
-system (create files, run commands or applications, write to the
-registry, etc).</p>
-<p>It returns a list of tuples containing two strings, the detected
-keyword, and the description of the corresponding malicious behaviour.
-(See the malware example above)</p>
+<div class="sourceCode" id="cb23"><pre class="sourceCode python"><code class="sourceCode python"><a class="sourceLine" id="cb23-1" data-line-number="1"><span class="im">from</span> oletools.olevba <span class="im">import</span> detect_autoexec</a>
+<a class="sourceLine" id="cb23-2" data-line-number="2">autoexec_keywords <span class="op">=</span> detect_autoexec(vba_code)</a>
+<a class="sourceLine" id="cb23-3" data-line-number="3"><span class="cf">if</span> autoexec_keywords:</a>
+<a class="sourceLine" id="cb23-4" data-line-number="4">    <span class="bu">print</span> <span class="st">&#39;Auto-executable macro keywords found:&#39;</span></a>
+<a class="sourceLine" id="cb23-5" data-line-number="5">    <span class="cf">for</span> keyword, description <span class="kw">in</span> autoexec_keywords:</a>
+<a class="sourceLine" id="cb23-6" data-line-number="6">        <span class="bu">print</span> <span class="st">&#39;</span><span class="sc">%s</span><span class="st">: </span><span class="sc">%s</span><span class="st">&#39;</span> <span class="op">%</span> (keyword, description)</a>
+<a class="sourceLine" id="cb23-7" data-line-number="7"><span class="cf">else</span>:</a>
+<a class="sourceLine" id="cb23-8" data-line-number="8">    <span class="bu">print</span> <span class="st">&#39;Auto-executable macro keywords: None found&#39;</span></a></code></pre></div>
+<h3 id="detect-suspicious-vba-keywords-deprecated">Detect suspicious VBA keywords (deprecated)</h3>
+<p><strong>Deprecated</strong>: It is preferable to use either scan_vba or VBA_Scanner to get all results at once.</p>
+<p>The function <strong>detect_suspicious</strong> checks if VBA macro code contains specific keywords often used by malware to act on the system (create files, run commands or applications, write to the registry, etc).</p>
+<p>It returns a list of tuples containing two strings, the detected keyword, and the description of the corresponding malicious behaviour. (See the malware example above)</p>
 <p>Sample usage:</p>
-<div class="sourceCode" id="cb24"><pre
-class="sourceCode python"><code class="sourceCode python"><span id="cb24-1"><a href="#cb24-1" aria-hidden="true" tabindex="-1"></a><span class="im">from</span> oletools.olevba <span class="im">import</span> detect_suspicious</span>
-<span id="cb24-2"><a href="#cb24-2" aria-hidden="true" tabindex="-1"></a>suspicious_keywords <span class="op">=</span> detect_suspicious(vba_code)</span>
-<span id="cb24-3"><a href="#cb24-3" aria-hidden="true" tabindex="-1"></a><span class="cf">if</span> suspicious_keywords:</span>
-<span id="cb24-4"><a href="#cb24-4" aria-hidden="true" tabindex="-1"></a>    <span class="bu">print</span> <span class="st">&#39;Suspicious VBA keywords found:&#39;</span></span>
-<span id="cb24-5"><a href="#cb24-5" aria-hidden="true" tabindex="-1"></a>    <span class="cf">for</span> keyword, description <span class="kw">in</span> suspicious_keywords:</span>
-<span id="cb24-6"><a href="#cb24-6" aria-hidden="true" tabindex="-1"></a>        <span class="bu">print</span> <span class="st">&#39;</span><span class="sc">%s</span><span class="st">: </span><span class="sc">%s</span><span class="st">&#39;</span> <span class="op">%</span> (keyword, description)</span>
-<span id="cb24-7"><a href="#cb24-7" aria-hidden="true" tabindex="-1"></a><span class="cf">else</span>:</span>
-<span id="cb24-8"><a href="#cb24-8" aria-hidden="true" tabindex="-1"></a>    <span class="bu">print</span> <span class="st">&#39;Suspicious VBA keywords: None found&#39;</span></span></code></pre></div>
-<h3 id="extract-potential-iocs-deprecated">Extract potential IOCs
-(deprecated)</h3>
-<p><strong>Deprecated</strong>: It is preferable to use either scan_vba
-or VBA_Scanner to get all results at once.</p>
-<p>The function <strong>detect_patterns</strong> checks if VBA macro
-code contains specific patterns of interest, that may be useful for
-malware analysis and detection (potential Indicators of Compromise): IP
-addresses, e-mail addresses, URLs, executable file names.</p>
-<p>It returns a list of tuples containing two strings, the pattern type,
-and the extracted value. (See the malware example above)</p>
+<div class="sourceCode" id="cb24"><pre class="sourceCode python"><code class="sourceCode python"><a class="sourceLine" id="cb24-1" data-line-number="1"><span class="im">from</span> oletools.olevba <span class="im">import</span> detect_suspicious</a>
+<a class="sourceLine" id="cb24-2" data-line-number="2">suspicious_keywords <span class="op">=</span> detect_suspicious(vba_code)</a>
+<a class="sourceLine" id="cb24-3" data-line-number="3"><span class="cf">if</span> suspicious_keywords:</a>
+<a class="sourceLine" id="cb24-4" data-line-number="4">    <span class="bu">print</span> <span class="st">&#39;Suspicious VBA keywords found:&#39;</span></a>
+<a class="sourceLine" id="cb24-5" data-line-number="5">    <span class="cf">for</span> keyword, description <span class="kw">in</span> suspicious_keywords:</a>
+<a class="sourceLine" id="cb24-6" data-line-number="6">        <span class="bu">print</span> <span class="st">&#39;</span><span class="sc">%s</span><span class="st">: </span><span class="sc">%s</span><span class="st">&#39;</span> <span class="op">%</span> (keyword, description)</a>
+<a class="sourceLine" id="cb24-7" data-line-number="7"><span class="cf">else</span>:</a>
+<a class="sourceLine" id="cb24-8" data-line-number="8">    <span class="bu">print</span> <span class="st">&#39;Suspicious VBA keywords: None found&#39;</span></a></code></pre></div>
+<h3 id="extract-potential-iocs-deprecated">Extract potential IOCs (deprecated)</h3>
+<p><strong>Deprecated</strong>: It is preferable to use either scan_vba or VBA_Scanner to get all results at once.</p>
+<p>The function <strong>detect_patterns</strong> checks if VBA macro code contains specific patterns of interest, that may be useful for malware analysis and detection (potential Indicators of Compromise): IP addresses, e-mail addresses, URLs, executable file names.</p>
+<p>It returns a list of tuples containing two strings, the pattern type, and the extracted value. (See the malware example above)</p>
 <p>Sample usage:</p>
-<div class="sourceCode" id="cb25"><pre
-class="sourceCode python"><code class="sourceCode python"><span id="cb25-1"><a href="#cb25-1" aria-hidden="true" tabindex="-1"></a><span class="im">from</span> oletools.olevba <span class="im">import</span> detect_patterns</span>
-<span id="cb25-2"><a href="#cb25-2" aria-hidden="true" tabindex="-1"></a>patterns <span class="op">=</span> detect_patterns(vba_code)</span>
-<span id="cb25-3"><a href="#cb25-3" aria-hidden="true" tabindex="-1"></a><span class="cf">if</span> patterns:</span>
-<span id="cb25-4"><a href="#cb25-4" aria-hidden="true" tabindex="-1"></a>    <span class="bu">print</span> <span class="st">&#39;Patterns found:&#39;</span></span>
-<span id="cb25-5"><a href="#cb25-5" aria-hidden="true" tabindex="-1"></a>    <span class="cf">for</span> pattern_type, value <span class="kw">in</span> patterns:</span>
-<span id="cb25-6"><a href="#cb25-6" aria-hidden="true" tabindex="-1"></a>        <span class="bu">print</span> <span class="st">&#39;</span><span class="sc">%s</span><span class="st">: </span><span class="sc">%s</span><span class="st">&#39;</span> <span class="op">%</span> (pattern_type, value)</span>
-<span id="cb25-7"><a href="#cb25-7" aria-hidden="true" tabindex="-1"></a><span class="cf">else</span>:</span>
-<span id="cb25-8"><a href="#cb25-8" aria-hidden="true" tabindex="-1"></a>    <span class="bu">print</span> <span class="st">&#39;Patterns: None found&#39;</span></span></code></pre></div>
+<div class="sourceCode" id="cb25"><pre class="sourceCode python"><code class="sourceCode python"><a class="sourceLine" id="cb25-1" data-line-number="1"><span class="im">from</span> oletools.olevba <span class="im">import</span> detect_patterns</a>
+<a class="sourceLine" id="cb25-2" data-line-number="2">patterns <span class="op">=</span> detect_patterns(vba_code)</a>
+<a class="sourceLine" id="cb25-3" data-line-number="3"><span class="cf">if</span> patterns:</a>
+<a class="sourceLine" id="cb25-4" data-line-number="4">    <span class="bu">print</span> <span class="st">&#39;Patterns found:&#39;</span></a>
+<a class="sourceLine" id="cb25-5" data-line-number="5">    <span class="cf">for</span> pattern_type, value <span class="kw">in</span> patterns:</a>
+<a class="sourceLine" id="cb25-6" data-line-number="6">        <span class="bu">print</span> <span class="st">&#39;</span><span class="sc">%s</span><span class="st">: </span><span class="sc">%s</span><span class="st">&#39;</span> <span class="op">%</span> (pattern_type, value)</a>
+<a class="sourceLine" id="cb25-7" data-line-number="7"><span class="cf">else</span>:</a>
+<a class="sourceLine" id="cb25-8" data-line-number="8">    <span class="bu">print</span> <span class="st">&#39;Patterns: None found&#39;</span></a></code></pre></div>
 <hr />
-<h2 id="python-oletools-documentation">python-oletools
-documentation</h2>
+<h2 id="python-oletools-documentation">python-oletools documentation</h2>
 <ul>
 <li><a href="Home.html">Home</a></li>
 <li><a href="License.html">License</a></li>
 <li><a href="Install.html">Install</a></li>
-<li><a href="Contribute.html">Contribute</a>, Suggest Improvements or
-Report Issues</li>
+<li><a href="Contribute.html">Contribute</a>, Suggest Improvements or Report Issues</li>
 <li>Tools:
 <ul>
 <li><a href="mraptor.html">mraptor</a></li>

--- a/oletools/doc/pyxswf.html
+++ b/oletools/doc/pyxswf.html
@@ -4,177 +4,25 @@
   <meta charset="utf-8" />
   <meta name="generator" content="pandoc" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
-  <title>-</title>
-  <style>
-    html {
-      line-height: 1.5;
-      font-family: Georgia, serif;
-      font-size: 20px;
-      color: #1a1a1a;
-      background-color: #fdfdfd;
-    }
-    body {
-      margin: 0 auto;
-      max-width: 36em;
-      padding-left: 50px;
-      padding-right: 50px;
-      padding-top: 50px;
-      padding-bottom: 50px;
-      hyphens: auto;
-      overflow-wrap: break-word;
-      text-rendering: optimizeLegibility;
-      font-kerning: normal;
-    }
-    @media (max-width: 600px) {
-      body {
-        font-size: 0.9em;
-        padding: 1em;
-      }
-      h1 {
-        font-size: 1.8em;
-      }
-    }
-    @media print {
-      body {
-        background-color: transparent;
-        color: black;
-        font-size: 12pt;
-      }
-      p, h2, h3 {
-        orphans: 3;
-        widows: 3;
-      }
-      h2, h3, h4 {
-        page-break-after: avoid;
-      }
-    }
-    p {
-      margin: 1em 0;
-    }
-    a {
-      color: #1a1a1a;
-    }
-    a:visited {
-      color: #1a1a1a;
-    }
-    img {
-      max-width: 100%;
-    }
-    h1, h2, h3, h4, h5, h6 {
-      margin-top: 1.4em;
-    }
-    h5, h6 {
-      font-size: 1em;
-      font-style: italic;
-    }
-    h6 {
-      font-weight: normal;
-    }
-    ol, ul {
-      padding-left: 1.7em;
-      margin-top: 1em;
-    }
-    li > ol, li > ul {
-      margin-top: 0;
-    }
-    blockquote {
-      margin: 1em 0 1em 1.7em;
-      padding-left: 1em;
-      border-left: 2px solid #e6e6e6;
-      color: #606060;
-    }
-    code {
-      font-family: Menlo, Monaco, 'Lucida Console', Consolas, monospace;
-      font-size: 85%;
-      margin: 0;
-    }
-    pre {
-      margin: 1em 0;
-      overflow: auto;
-    }
-    pre code {
-      padding: 0;
-      overflow: visible;
-      overflow-wrap: normal;
-    }
-    .sourceCode {
-     background-color: transparent;
-     overflow: visible;
-    }
-    hr {
-      background-color: #1a1a1a;
-      border: none;
-      height: 1px;
-      margin: 1em 0;
-    }
-    table {
-      margin: 1em 0;
-      border-collapse: collapse;
-      width: 100%;
-      overflow-x: auto;
-      display: block;
-      font-variant-numeric: lining-nums tabular-nums;
-    }
-    table caption {
-      margin-bottom: 0.75em;
-    }
-    tbody {
-      margin-top: 0.5em;
-      border-top: 1px solid #1a1a1a;
-      border-bottom: 1px solid #1a1a1a;
-    }
-    th {
-      border-top: 1px solid #1a1a1a;
-      padding: 0.25em 0.5em 0.25em 0.5em;
-    }
-    td {
-      padding: 0.125em 0.5em 0.25em 0.5em;
-    }
-    header {
-      margin-bottom: 4em;
-      text-align: center;
-    }
-    #TOC li {
-      list-style: none;
-    }
-    #TOC ul {
-      padding-left: 1.3em;
-    }
-    #TOC > ul {
-      padding-left: 0;
-    }
-    #TOC a:not(:hover) {
-      text-decoration: none;
-    }
-    code{white-space: pre-wrap;}
-    span.smallcaps{font-variant: small-caps;}
-    span.underline{text-decoration: underline;}
-    div.column{display: inline-block; vertical-align: top; width: 50%;}
-    div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
-    ul.task-list{list-style: none;}
-    .display.math{display: block; text-align: center; margin: 0.5rem auto;}
+  <title>Untitled</title>
+  <style type="text/css">
+      code{white-space: pre-wrap;}
+      span.smallcaps{font-variant: small-caps;}
+      span.underline{text-decoration: underline;}
+      div.column{display: inline-block; vertical-align: top; width: 50%;}
   </style>
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
 <h1 id="pyxswf">pyxswf</h1>
-<p>pyxswf is a script to detect, extract and analyze Flash objects (SWF
-files) that may be embedded in files such as MS Office documents
-(e.g. Word, Excel), which is especially useful for malware analysis.</p>
-<p>It is part of the <a
-href="http://www.decalage.info/python/oletools">python-oletools</a>
-package.</p>
-<p>pyxswf is an extension to <a
-href="http://hooked-on-mnemonics.blogspot.nl/2011/12/xxxswfpy.html">xxxswf.py</a>
-published by Alexander Hanel.</p>
-<p>Compared to xxxswf, it can extract streams from MS Office documents
-by parsing their OLE structure properly, which is necessary when streams
-are fragmented. Stream fragmentation is a known obfuscation technique,
-as explained on <a
-href="http://web.archive.org/web/20121118021207/http://www.breakingpointsystems.com/resources/blog/evasion-with-ole2-fragmentation/">http://www.breakingpointsystems.com/resources/blog/evasion-with-ole2-fragmentation/</a></p>
-<p>It can also extract Flash objects from RTF documents, by parsing
-embedded objects encoded in hexadecimal format (-f option).</p>
-<p>For this, simply add the -o option to work on OLE streams rather than
-raw files, or the -f option to work on RTF files.</p>
+<p>pyxswf is a script to detect, extract and analyze Flash objects (SWF files) that may be embedded in files such as MS Office documents (e.g. Word, Excel), which is especially useful for malware analysis.</p>
+<p>It is part of the <a href="http://www.decalage.info/python/oletools">python-oletools</a> package.</p>
+<p>pyxswf is an extension to <a href="http://hooked-on-mnemonics.blogspot.nl/2011/12/xxxswfpy.html">xxxswf.py</a> published by Alexander Hanel.</p>
+<p>Compared to xxxswf, it can extract streams from MS Office documents by parsing their OLE structure properly, which is necessary when streams are fragmented. Stream fragmentation is a known obfuscation technique, as explained on <a href="http://web.archive.org/web/20121118021207/http://www.breakingpointsystems.com/resources/blog/evasion-with-ole2-fragmentation/">http://www.breakingpointsystems.com/resources/blog/evasion-with-ole2-fragmentation/</a></p>
+<p>It can also extract Flash objects from RTF documents, by parsing embedded objects encoded in hexadecimal format (-f option).</p>
+<p>For this, simply add the -o option to work on OLE streams rather than raw files, or the -f option to work on RTF files.</p>
 <h2 id="usage">Usage</h2>
 <pre class="text"><code>Usage: pyxswf [options] &lt;file.bad&gt;
 
@@ -197,10 +45,7 @@ Options:
                         Will recursively scan a directory for files that
                         contain SWFs. Must provide path in quotes
   -c, --compress        Compresses the SWF using Zlib</code></pre>
-<h3
-id="example-1---detecting-and-extracting-a-swf-file-from-a-word-document-on-windows">Example
-1 - detecting and extracting a SWF file from a Word document on
-Windows:</h3>
+<h3 id="example-1---detecting-and-extracting-a-swf-file-from-a-word-document-on-windows">Example 1 - detecting and extracting a SWF file from a Word document on Windows:</h3>
 <pre class="text"><code>C:\oletools&gt;pyxswf -o word_flash.doc
 OLE stream: &#39;Contents&#39;
 [SUMMARY] 1 SWF(s) in MD5:993664cc86f60d52d671b6610813cfd1:Contents
@@ -211,28 +56,22 @@ OLE stream: &#39;Contents&#39;
 [SUMMARY] 1 SWF(s) in MD5:993664cc86f60d52d671b6610813cfd1:Contents
         [ADDR] SWF 1 at 0x8  - FWS Header
                 [FILE] Carved SWF MD5: 2498e9c0701dc0e461ab4358f9102bc5.swf</code></pre>
-<h3
-id="example-2---detecting-and-extracting-a-swf-file-from-a-rtf-document-on-windows">Example
-2 - detecting and extracting a SWF file from a RTF document on
-Windows:</h3>
+<h3 id="example-2---detecting-and-extracting-a-swf-file-from-a-rtf-document-on-windows">Example 2 - detecting and extracting a SWF file from a RTF document on Windows:</h3>
 <pre class="text"><code>C:\oletools&gt;pyxswf -xf &quot;rtf_flash.rtf&quot;
 RTF embedded object size 1498557 at index 000036DD
 [SUMMARY] 1 SWF(s) in MD5:46a110548007e04f4043785ac4184558:RTF_embedded_object_0
 00036DD
         [ADDR] SWF 1 at 0xc40  - FWS Header
                 [FILE] Carved SWF MD5: 2498e9c0701dc0e461ab4358f9102bc5.swf</code></pre>
-<h2 id="how-to-use-pyxswf-in-python-applications">How to use pyxswf in
-Python applications</h2>
+<h2 id="how-to-use-pyxswf-in-python-applications">How to use pyxswf in Python applications</h2>
 <p>TODO</p>
 <hr />
-<h2 id="python-oletools-documentation">python-oletools
-documentation</h2>
+<h2 id="python-oletools-documentation">python-oletools documentation</h2>
 <ul>
 <li><a href="Home.html">Home</a></li>
 <li><a href="License.html">License</a></li>
 <li><a href="Install.html">Install</a></li>
-<li><a href="Contribute.html">Contribute</a>, Suggest Improvements or
-Report Issues</li>
+<li><a href="Contribute.html">Contribute</a>, Suggest Improvements or Report Issues</li>
 <li>Tools:
 <ul>
 <li><a href="mraptor.html">mraptor</a></li>

--- a/oletools/doc/rtfobj.html
+++ b/oletools/doc/rtfobj.html
@@ -4,234 +4,88 @@
   <meta charset="utf-8" />
   <meta name="generator" content="pandoc" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
-  <title>-</title>
-  <style>
-    html {
-      line-height: 1.5;
-      font-family: Georgia, serif;
-      font-size: 20px;
-      color: #1a1a1a;
-      background-color: #fdfdfd;
-    }
-    body {
-      margin: 0 auto;
-      max-width: 36em;
-      padding-left: 50px;
-      padding-right: 50px;
-      padding-top: 50px;
-      padding-bottom: 50px;
-      hyphens: auto;
-      overflow-wrap: break-word;
-      text-rendering: optimizeLegibility;
-      font-kerning: normal;
-    }
-    @media (max-width: 600px) {
-      body {
-        font-size: 0.9em;
-        padding: 1em;
-      }
-      h1 {
-        font-size: 1.8em;
-      }
-    }
-    @media print {
-      body {
-        background-color: transparent;
-        color: black;
-        font-size: 12pt;
-      }
-      p, h2, h3 {
-        orphans: 3;
-        widows: 3;
-      }
-      h2, h3, h4 {
-        page-break-after: avoid;
-      }
-    }
-    p {
-      margin: 1em 0;
-    }
-    a {
-      color: #1a1a1a;
-    }
-    a:visited {
-      color: #1a1a1a;
-    }
-    img {
-      max-width: 100%;
-    }
-    h1, h2, h3, h4, h5, h6 {
-      margin-top: 1.4em;
-    }
-    h5, h6 {
-      font-size: 1em;
-      font-style: italic;
-    }
-    h6 {
-      font-weight: normal;
-    }
-    ol, ul {
-      padding-left: 1.7em;
-      margin-top: 1em;
-    }
-    li > ol, li > ul {
-      margin-top: 0;
-    }
-    blockquote {
-      margin: 1em 0 1em 1.7em;
-      padding-left: 1em;
-      border-left: 2px solid #e6e6e6;
-      color: #606060;
-    }
-    code {
-      font-family: Menlo, Monaco, 'Lucida Console', Consolas, monospace;
-      font-size: 85%;
-      margin: 0;
-    }
-    pre {
-      margin: 1em 0;
-      overflow: auto;
-    }
-    pre code {
-      padding: 0;
-      overflow: visible;
-      overflow-wrap: normal;
-    }
-    .sourceCode {
-     background-color: transparent;
-     overflow: visible;
-    }
-    hr {
-      background-color: #1a1a1a;
-      border: none;
-      height: 1px;
-      margin: 1em 0;
-    }
-    table {
-      margin: 1em 0;
-      border-collapse: collapse;
-      width: 100%;
-      overflow-x: auto;
-      display: block;
-      font-variant-numeric: lining-nums tabular-nums;
-    }
-    table caption {
-      margin-bottom: 0.75em;
-    }
-    tbody {
-      margin-top: 0.5em;
-      border-top: 1px solid #1a1a1a;
-      border-bottom: 1px solid #1a1a1a;
-    }
-    th {
-      border-top: 1px solid #1a1a1a;
-      padding: 0.25em 0.5em 0.25em 0.5em;
-    }
-    td {
-      padding: 0.125em 0.5em 0.25em 0.5em;
-    }
-    header {
-      margin-bottom: 4em;
-      text-align: center;
-    }
-    #TOC li {
-      list-style: none;
-    }
-    #TOC ul {
-      padding-left: 1.3em;
-    }
-    #TOC > ul {
-      padding-left: 0;
-    }
-    #TOC a:not(:hover) {
-      text-decoration: none;
-    }
-    code{white-space: pre-wrap;}
-    span.smallcaps{font-variant: small-caps;}
-    span.underline{text-decoration: underline;}
-    div.column{display: inline-block; vertical-align: top; width: 50%;}
-    div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
-    ul.task-list{list-style: none;}
-    pre > code.sourceCode { white-space: pre; position: relative; }
-    pre > code.sourceCode > span { display: inline-block; line-height: 1.25; }
-    pre > code.sourceCode > span:empty { height: 1.2em; }
-    .sourceCode { overflow: visible; }
-    code.sourceCode > span { color: inherit; text-decoration: inherit; }
-    div.sourceCode { margin: 1em 0; }
-    pre.sourceCode { margin: 0; }
-    @media screen {
-    div.sourceCode { overflow: auto; }
-    }
-    @media print {
-    pre > code.sourceCode { white-space: pre-wrap; }
-    pre > code.sourceCode > span { text-indent: -5em; padding-left: 5em; }
-    }
-    pre.numberSource code
-      { counter-reset: source-line 0; }
-    pre.numberSource code > span
-      { position: relative; left: -4em; counter-increment: source-line; }
-    pre.numberSource code > span > a:first-child::before
-      { content: counter(source-line);
-        position: relative; left: -1em; text-align: right; vertical-align: baseline;
-        border: none; display: inline-block;
-        -webkit-touch-callout: none; -webkit-user-select: none;
-        -khtml-user-select: none; -moz-user-select: none;
-        -ms-user-select: none; user-select: none;
-        padding: 0 4px; width: 4em;
-        color: #aaaaaa;
-      }
-    pre.numberSource { margin-left: 3em; border-left: 1px solid #aaaaaa;  padding-left: 4px; }
-    div.sourceCode
-      {   }
-    @media screen {
-    pre > code.sourceCode > span > a:first-child::before { text-decoration: underline; }
-    }
-    code span.al { color: #ff0000; font-weight: bold; } /* Alert */
-    code span.an { color: #60a0b0; font-weight: bold; font-style: italic; } /* Annotation */
-    code span.at { color: #7d9029; } /* Attribute */
-    code span.bn { color: #40a070; } /* BaseN */
-    code span.bu { color: #008000; } /* BuiltIn */
-    code span.cf { color: #007020; font-weight: bold; } /* ControlFlow */
-    code span.ch { color: #4070a0; } /* Char */
-    code span.cn { color: #880000; } /* Constant */
-    code span.co { color: #60a0b0; font-style: italic; } /* Comment */
-    code span.cv { color: #60a0b0; font-weight: bold; font-style: italic; } /* CommentVar */
-    code span.do { color: #ba2121; font-style: italic; } /* Documentation */
-    code span.dt { color: #902000; } /* DataType */
-    code span.dv { color: #40a070; } /* DecVal */
-    code span.er { color: #ff0000; font-weight: bold; } /* Error */
-    code span.ex { } /* Extension */
-    code span.fl { color: #40a070; } /* Float */
-    code span.fu { color: #06287e; } /* Function */
-    code span.im { color: #008000; font-weight: bold; } /* Import */
-    code span.in { color: #60a0b0; font-weight: bold; font-style: italic; } /* Information */
-    code span.kw { color: #007020; font-weight: bold; } /* Keyword */
-    code span.op { color: #666666; } /* Operator */
-    code span.ot { color: #007020; } /* Other */
-    code span.pp { color: #bc7a00; } /* Preprocessor */
-    code span.sc { color: #4070a0; } /* SpecialChar */
-    code span.ss { color: #bb6688; } /* SpecialString */
-    code span.st { color: #4070a0; } /* String */
-    code span.va { color: #19177c; } /* Variable */
-    code span.vs { color: #4070a0; } /* VerbatimString */
-    code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warning */
-    .display.math{display: block; text-align: center; margin: 0.5rem auto;}
+  <title>Untitled</title>
+  <style type="text/css">
+      code{white-space: pre-wrap;}
+      span.smallcaps{font-variant: small-caps;}
+      span.underline{text-decoration: underline;}
+      div.column{display: inline-block; vertical-align: top; width: 50%;}
   </style>
+  <style type="text/css">
+a.sourceLine { display: inline-block; line-height: 1.25; }
+a.sourceLine { pointer-events: none; color: inherit; text-decoration: inherit; }
+a.sourceLine:empty { height: 1.2em; position: absolute; }
+.sourceCode { overflow: visible; }
+code.sourceCode { white-space: pre; position: relative; }
+div.sourceCode { margin: 1em 0; }
+pre.sourceCode { margin: 0; }
+@media screen {
+div.sourceCode { overflow: auto; }
+}
+@media print {
+code.sourceCode { white-space: pre-wrap; }
+a.sourceLine { text-indent: -1em; padding-left: 1em; }
+}
+pre.numberSource a.sourceLine
+  { position: relative; }
+pre.numberSource a.sourceLine:empty
+  { position: absolute; }
+pre.numberSource a.sourceLine::before
+  { content: attr(data-line-number);
+    position: absolute; left: -5em; text-align: right; vertical-align: baseline;
+    border: none; pointer-events: all;
+    -webkit-touch-callout: none; -webkit-user-select: none;
+    -khtml-user-select: none; -moz-user-select: none;
+    -ms-user-select: none; user-select: none;
+    padding: 0 4px; width: 4em;
+    color: #aaaaaa;
+  }
+pre.numberSource { margin-left: 3em; border-left: 1px solid #aaaaaa;  padding-left: 4px; }
+div.sourceCode
+  {  }
+@media screen {
+a.sourceLine::before { text-decoration: underline; }
+}
+code span.al { color: #ff0000; font-weight: bold; } /* Alert */
+code span.an { color: #60a0b0; font-weight: bold; font-style: italic; } /* Annotation */
+code span.at { color: #7d9029; } /* Attribute */
+code span.bn { color: #40a070; } /* BaseN */
+code span.bu { } /* BuiltIn */
+code span.cf { color: #007020; font-weight: bold; } /* ControlFlow */
+code span.ch { color: #4070a0; } /* Char */
+code span.cn { color: #880000; } /* Constant */
+code span.co { color: #60a0b0; font-style: italic; } /* Comment */
+code span.cv { color: #60a0b0; font-weight: bold; font-style: italic; } /* CommentVar */
+code span.do { color: #ba2121; font-style: italic; } /* Documentation */
+code span.dt { color: #902000; } /* DataType */
+code span.dv { color: #40a070; } /* DecVal */
+code span.er { color: #ff0000; font-weight: bold; } /* Error */
+code span.ex { } /* Extension */
+code span.fl { color: #40a070; } /* Float */
+code span.fu { color: #06287e; } /* Function */
+code span.im { } /* Import */
+code span.in { color: #60a0b0; font-weight: bold; font-style: italic; } /* Information */
+code span.kw { color: #007020; font-weight: bold; } /* Keyword */
+code span.op { color: #666666; } /* Operator */
+code span.ot { color: #007020; } /* Other */
+code span.pp { color: #bc7a00; } /* Preprocessor */
+code span.sc { color: #4070a0; } /* SpecialChar */
+code span.ss { color: #bb6688; } /* SpecialString */
+code span.st { color: #4070a0; } /* String */
+code span.va { color: #19177c; } /* Variable */
+code span.vs { color: #4070a0; } /* VerbatimString */
+code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warning */
+  </style>
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
 </head>
 <body>
 <h1 id="rtfobj">rtfobj</h1>
-<p>rtfobj is a Python module to detect and extract embedded objects
-stored in RTF files, such as OLE objects. It can also detect OLE Package
-objects, and extract the embedded files.</p>
-<p>Since v0.50, rtfobj contains a custom RTF parser that has been
-designed to match MS Word’s behaviour, in order to handle obfuscated RTF
-files. See my article <a
-href="http://decalage.info/rtf_tricks">“Anti-Analysis Tricks in
-Weaponized RTF”</a> for some concrete examples.</p>
+<p>rtfobj is a Python module to detect and extract embedded objects stored in RTF files, such as OLE objects. It can also detect OLE Package objects, and extract the embedded files.</p>
+<p>Since v0.50, rtfobj contains a custom RTF parser that has been designed to match MS Word’s behaviour, in order to handle obfuscated RTF files. See my article <a href="http://decalage.info/rtf_tricks">“Anti-Analysis Tricks in Weaponized RTF”</a> for some concrete examples.</p>
 <p>rtfobj can be used as a Python library or a command-line tool.</p>
-<p>It is part of the <a
-href="http://www.decalage.info/python/oletools">python-oletools</a>
-package.</p>
+<p>It is part of the <a href="http://www.decalage.info/python/oletools">python-oletools</a> package.</p>
 <h2 id="usage">Usage</h2>
 <pre class="text"><code>rtfobj [options] &lt;filename&gt; [filename2 ...]
 
@@ -253,41 +107,28 @@ Options:
                         to a file, for example &quot;-s 2&quot;. Use &quot;-s all&quot; to save
                         all objects at once.
   -d OUTPUT_DIR         use specified directory to save output files.</code></pre>
-<p>rtfobj displays a list of the OLE and Package objects that have been
-detected, with their attributes such as class and filename.</p>
-<p>When an OLE Package object contains an executable file or script, it
-is highlighted as such. For example:</p>
+<p>rtfobj displays a list of the OLE and Package objects that have been detected, with their attributes such as class and filename.</p>
+<p>When an OLE Package object contains an executable file or script, it is highlighted as such. For example:</p>
 <p><img src="rtfobj1.png" /></p>
-<p>To extract an object or file, use the option -s followed by the
-object number as shown in the table.</p>
+<p>To extract an object or file, use the option -s followed by the object number as shown in the table.</p>
 <p>Example:</p>
 <pre class="text"><code>rtfobj -s 0</code></pre>
-<p>It extracts and decodes the corresponding object, and saves it as a
-file named “object_xxxx.bin”, xxxx being the location of the object in
-the RTF file.</p>
-<h2 id="how-to-use-rtfobj-in-python-applications">How to use rtfobj in
-Python applications</h2>
-<p>As of v0.50, the API has changed significantly and it is not final
-yet. For now, see the class RtfObjectParser in the code.</p>
-<h3 id="deprecated-api-still-functional">Deprecated API (still
-functional):</h3>
-<p>rtf_iter_objects(filename) is an iterator which yields a tuple
-(index, orig_len, object) providing the index of each hexadecimal stream
-in the RTF file, and the corresponding decoded object.</p>
+<p>It extracts and decodes the corresponding object, and saves it as a file named “object_xxxx.bin”, xxxx being the location of the object in the RTF file.</p>
+<h2 id="how-to-use-rtfobj-in-python-applications">How to use rtfobj in Python applications</h2>
+<p>As of v0.50, the API has changed significantly and it is not final yet. For now, see the class RtfObjectParser in the code.</p>
+<h3 id="deprecated-api-still-functional">Deprecated API (still functional):</h3>
+<p>rtf_iter_objects(filename) is an iterator which yields a tuple (index, orig_len, object) providing the index of each hexadecimal stream in the RTF file, and the corresponding decoded object.</p>
 <p>Example:</p>
-<div class="sourceCode" id="cb3"><pre
-class="sourceCode python"><code class="sourceCode python"><span id="cb3-1"><a href="#cb3-1" aria-hidden="true" tabindex="-1"></a><span class="im">from</span> oletools <span class="im">import</span> rtfobj</span>
-<span id="cb3-2"><a href="#cb3-2" aria-hidden="true" tabindex="-1"></a><span class="cf">for</span> index, orig_len, data <span class="kw">in</span> rtfobj.rtf_iter_objects(<span class="st">&quot;myfile.rtf&quot;</span>):</span>
-<span id="cb3-3"><a href="#cb3-3" aria-hidden="true" tabindex="-1"></a>    <span class="bu">print</span>(<span class="st">&#39;found object size </span><span class="sc">%d</span><span class="st"> at index </span><span class="sc">%08X</span><span class="st">&#39;</span> <span class="op">%</span> (<span class="bu">len</span>(data), index))</span></code></pre></div>
+<div class="sourceCode" id="cb3"><pre class="sourceCode python"><code class="sourceCode python"><a class="sourceLine" id="cb3-1" data-line-number="1"><span class="im">from</span> oletools <span class="im">import</span> rtfobj</a>
+<a class="sourceLine" id="cb3-2" data-line-number="2"><span class="cf">for</span> index, orig_len, data <span class="kw">in</span> rtfobj.rtf_iter_objects(<span class="st">&quot;myfile.rtf&quot;</span>):</a>
+<a class="sourceLine" id="cb3-3" data-line-number="3">    <span class="bu">print</span>(<span class="st">&#39;found object size </span><span class="sc">%d</span><span class="st"> at index </span><span class="sc">%08X</span><span class="st">&#39;</span> <span class="op">%</span> (<span class="bu">len</span>(data), index))</a></code></pre></div>
 <hr />
-<h2 id="python-oletools-documentation">python-oletools
-documentation</h2>
+<h2 id="python-oletools-documentation">python-oletools documentation</h2>
 <ul>
 <li><a href="Home.html">Home</a></li>
 <li><a href="License.html">License</a></li>
 <li><a href="Install.html">Install</a></li>
-<li><a href="Contribute.html">Contribute</a>, Suggest Improvements or
-Report Issues</li>
+<li><a href="Contribute.html">Contribute</a>, Suggest Improvements or Report Issues</li>
 <li>Tools:
 <ul>
 <li><a href="mraptor.html">mraptor</a></li>

--- a/oletools/olevba.py
+++ b/oletools/olevba.py
@@ -32,7 +32,7 @@ https://github.com/unixfreak0037/officeparser
 
 # === LICENSE ==================================================================
 
-# olevba is copyright (c) 2014-2024 Philippe Lagadec (http://www.decalage.info)
+# olevba is copyright (c) 2014-2025 Philippe Lagadec (http://www.decalage.info)
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without modification,
@@ -236,7 +236,7 @@ from __future__ import print_function
 # 2021-04-14       PL: - added detection of Workbook_BeforeClose (issue #518)
 # 2021-11-09       KJ: - added PROJECTCOMPATVERSION Record on dir Stream
 
-__version__ = '0.60.2'
+__version__ = '0.60.3'
 
 #------------------------------------------------------------------------------
 # TODO:
@@ -4112,7 +4112,6 @@ class VBA_Parser_CLI(VBA_Parser):
             for kw_type, keyword, description in results:
                 color_type = COLOR_TYPE.get(kw_type, None)
                 if color_type:
-
                     # Prevent malicious actors from performing anti-analysis by replacing
                     # character 27 (ESC) with \e.
                     # See more: https://www.youtube.com/watch?v=3T2Al3jdY38

--- a/oletools/olevba.py
+++ b/oletools/olevba.py
@@ -4112,6 +4112,11 @@ class VBA_Parser_CLI(VBA_Parser):
             for kw_type, keyword, description in results:
                 color_type = COLOR_TYPE.get(kw_type, None)
                 if color_type:
+
+                    # Prevent malicious actors from performing anti-analysis by replacing
+                    # character 27 (ESC) with \e.
+                    # See more: https://www.youtube.com/watch?v=3T2Al3jdY38
+                    vba_code = vba_code.replace("\x1b", "\\e")
                     vba_code = vba_code.replace(keyword, '{auto%s}%s{/%s}' % (color_type, keyword, color_type))
         return vba_code
 

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ import os, fnmatch
 #--- METADATA -----------------------------------------------------------------
 
 name         = "oletools"
-version      = '0.60.2'
+version      = '0.60.3'
 desc         = "Python tools to analyze security characteristics of MS Office and OLE files (also called Structured Storage, Compound File Binary Format or Compound Document File Format), for Malware Analysis and Incident Response #DFIR"
 long_desc    = open('oletools/README.rst').read()
 author       = "Philippe Lagadec"


### PR DESCRIPTION
By replacing the escape character with \e, user defined escape sequences wont be rendered in the output. This prevents malicious actors from performing anti-analysis.

**Before**
![image](https://github.com/user-attachments/assets/108b4922-8bfa-437f-b771-f8f7f5d4171a)

**After**
![image](https://github.com/user-attachments/assets/b3303589-45db-4224-9487-954214c4cd89)