### PR TITLE
fix: msodde output was repeating DDE links

### DIFF
--- a/oletools/msodde.py
+++ b/oletools/msodde.py
@@ -1009,7 +1009,7 @@ def main(cmd_line_args=None):
 
     logger.print_str('DDE Links:')
     for link in text.splitlines():
-        logger.print_str(text, type='dde-link')
+        logger.print_str(link, type='dde-link')
 
     log_helper.end_logging()
 


### PR DESCRIPTION
## Summary

Bug in msodde.py line 1012: the for loop was passing text instead of link to logger.print_str(), causing each DDE to be printed N times.

## Changes

### oletools/msodde.py

Fixed the for loop to use link variable instead of text.

Fixes #871