### PR TITLE
Fix TypeError in vba_collapse_long_lines when given bytes

### DIFF
--- a/oletools/olevba.py
+++ b/oletools/olevba.py
@@ -2126,6 +2126,14 @@ def vba_collapse_long_lines(vba_code):
     :param vba_code: str, VBA module code
     :return: str, VBA module code with long lines collapsed
     """
+    # Some obfuscated maldocs and certain VBA-stomping layouts reach this with
+    # bytes rather than str, so the str .replace() calls below raise
+    # 'TypeError: a bytes-like object is required, not str' and abort the scan via
+    # VBA_Scanner / analyze_macros. Decode losslessly first (latin-1 is a total
+    # byte->codepoint map that never raises and preserves the ASCII keywords/IOCs
+    # the scanner keys on); str input is unchanged.
+    if isinstance(vba_code, bytes):
+        vba_code = vba_code.decode('latin-1')
     # TODO: use a regex instead, to allow whitespaces after the underscore?
     try:
         vba_code = vba_code.replace(' _\r\n', ' ')


### PR DESCRIPTION
### Problem
`vba_collapse_long_lines(vba_code)` assumes `vba_code` is `str` and calls `vba_code.replace(' _\r\n', ' ')`. Some obfuscated maldocs and certain VBA-stomping layouts reach it with `bytes`, so those `str.replace` calls raise `TypeError: a bytes-like object is required, not 'str'`. The exception re-raises out through `VBA_Scanner` / `analyze_macros`, aborting the entire scan of the document.

### Fix
If `vba_code` is `bytes`, decode it to `str` via latin-1 before the existing logic. latin-1 is a total, lossless byte→codepoint mapping that never raises and preserves the ASCII keywords/IOCs the downstream scanner relies on. `str` input is unchanged, so there is no behaviour change on the normal path.

Minimal and self-contained (one guard clause). Happy to add a regression test with a specific fixture if you'd prefer.