### PR TITLE
fix(olevba): make E-mail address regex use raw '\b' instead of litera…

### DIFF
--- a/oletools/olevba.py
+++ b/oletools/olevba.py
@@ -870,7 +870,7 @@ RE_PATTERNS = (
     ('URL', re.compile(URL_RE)),
     ('IPv4 address', re.compile(IPv4)),
     # TODO: add IPv6
-    ('E-mail address', re.compile(r'(?i)\b[A-Z0-9._%+-]+@' + SERVER + '\b')),
+    ('E-mail address', re.compile(r'(?i)\b[A-Z0-9._%+-]+@' + SERVER + r'\b')),
     # ('Domain name', re.compile(r'(?=^.{1,254}$)(^(?:(?!\d+\.|-)[a-zA-Z0-9_\-]{1,63}(?<!-)\.?)+(?:[a-zA-Z]{2,})$)')),
     # Executable file name with known extensions (except .com which is present in many URLs, and .application):
     ("Executable file name", re.compile(

--- a/tests/olevba/test_basic.py
+++ b/tests/olevba/test_basic.py
@@ -10,6 +10,7 @@ import json
 
 # Directory with test data, independent of current working directory
 from tests.test_utils import DATA_BASE_DIR, call_and_capture
+from oletools.olevba import detect_patterns
 
 
 class TestOlevbaBasic(unittest.TestCase):
@@ -168,6 +169,18 @@ class TestOlevbaBasic(unittest.TestCase):
 
         # vba contents:
         self.assertIn('Sub Action_Click()\n  MsgBox "The action button clicked!"\nEnd Sub', output)
+
+    def test_detect_email_address(self):
+        """Test that detect_patterns finds e-mail address IOCs.
+
+        Regression test: the 'E-mail address' regex used to be built by
+        concatenating a raw string with a plain string literal containing
+        '\\b', which Python compiles to a literal backspace character
+        instead of a regex word-boundary token. That made the pattern
+        unmatchable against any real text.
+        """
+        results = detect_patterns('x = "attacker@evil.example.com"')
+        self.assertIn(('E-mail address', 'attacker@evil.example.com'), results)
 
 
 # just in case somebody calls this file as a script


### PR DESCRIPTION
…l backspace

RE_PATTERNS concatenated r'...' + SERVER + '\b' (non-raw), so Python compiled '\b' to a backspace char (\x08) instead of the regex word-boundary token, making the e-mail IOC pattern unmatchable. Fixed by using r'\b'. Added a regression test for e-mail IOC detection.